### PR TITLE
chore: Remove end_of_line setting from all files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,6 @@ root = true
 [*]
 indent_style = space
 indent_size = 4
-end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true


### PR DESCRIPTION
Remove end_of_line setting from .editorconfig

## Description

Setting lf conflicts with git on windows usage of autoclrf.

I'm not sure how we want to handle line endings, but generally git will convert depending on the platform. Having it unset tends to be a better and will use clrf on windows and mac / linux use lf.

Having this set often results in files of mixed line endings on windows, this fixes that issue.

Ticket NA

## Type of Change

Editor config fix.

## Testing

N/A

## Checklist

- [x] Self-reviewed
- [x] Documentation updated
- [x] Tests added/pass
