### PR TITLE
Bump down minimum dotnet version to 10.0.100

### DIFF
--- a/.aspire/settings.json
+++ b/.aspire/settings.json
@@ -1,3 +1,6 @@
 {
-  "appHostPath": "../services/apphost/Naur.AppHost.csproj"
+  "appHostPath": "../services/apphost/Naur.AppHost.csproj",
+  "features": {
+    "dotnetSdkInstallationEnabled": "true"
+  }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.102",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   },
   "test": {


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
This commit bumps the minimum dotnet verison down to 10.0.100, as well as enabling a config option to allow aspire to download dotnet sdk's for ease of installation.

<!-- Link a ticket: "Ticket #123", "Fixes #123", "Closes #123", "Resolves #123", or "Ticket NA" if none -->

Ticket NA

## Type of Change

Aspire config change

## Testing

running `aspire run`

<!--
## Screenshots
Add screenshots if applicable
-->

## Checklist

- [ ] Self-reviewed
- [ ] Documentation updated
- [ ] Tests added/pass
