### PR TITLE
fix: correct GitHub Actions cache paths in deploy workflow

### DIFF
--- a/.github/workflows/deploy-netlify.yml
+++ b/.github/workflows/deploy-netlify.yml
@@ -41,13 +41,14 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          path: .next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('../../package-lock.json') }}
+          path: services/${{ inputs.service }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}
           restore-keys: ${{ runner.os }}-nextjs-
 
+      # Deliberately run 'Install Dependencies' at the repository root (working-directory: .)
       - name: Install Dependencies
-        working-directory: .
         run: npm ci
+        working-directory: .
 
       - name: Deploy to Netlify
         id: deploy


### PR DESCRIPTION
## Description

Fixes GitHub Actions workflow failure caused by invalid relative path patterns in `hashFiles()` function. 
The `hashFiles()` function doesn't allow `..` parent directory references. Updated all paths to be relative to the repository root instead of the working directory.

Ticket NA

## Type of Change

Bug fix for website prod deploy

## Testing

Triggered manual workflow in a forked repository
Test link: https://github.com/Luna-Salamanca/naur/actions/runs/21805185378

## Checklist

- [x] Self-reviewed
- [x] Documentation updated
- [x] Tests added/pass
