### PR TITLE
bump(dep): discordgo to v0.29.0

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -56,7 +56,7 @@ services:
     vendor_dir: services/clearingway/vendor
     audited_packages:
       - name: github.com/bwmarrin/discordgo
-        version: v0.28.2-0.20240514123316-2c9c884e4fae
+        version: v0.29.0
         license: BSD-3-Clause
         security_tier: high
         source: https://github.com/bwmarrin/discordgo
@@ -80,8 +80,8 @@ services:
         source: https://github.com/microsoft/playwright
 metadata:
   update_policy: manual
-  last_audit: 2026-01-21
-  next_audit: 2026-02-04
+  last_audit: 2026-02-08
+  next_audit: 2026-03-08
   security_tiers:
     critical: Core framework or authentication packages
     high: Network-facing or data-processing packages


### PR DESCRIPTION
## Description

This PR updates the discordgo dependency to v0.29.0 in clearingway.

Ticket NA

## Type of Change

dependencies.yml update

## Testing

- Verified `go.mod` file in clearingway.
- Ran `py check-dependency-sync.py --fix` and `make validate-deps` to ensure dependency consistency.

## Checklist

- [x] Self-reviewed
- [x] Documentation updated
- [x] Tests added/pass
