### PR TITLE
reason field char restriction updated to varchar 1024

### DIFF
--- a/services/moddingway/moddingway_api/routes/banforms_routes.py
+++ b/services/moddingway/moddingway_api/routes/banforms_routes.py
@@ -61,6 +61,11 @@ async def submit_form(request: FormRequest):
             submission_timestamp=datetime.now(UTC),
         )
 
+        if len(form.reason) > 1024:
+            return {
+                "detail": "Appeal reason max length is 1024 characters. Please shorten the appeal reason."
+            }
+
         result = banforms_database.add_form(form)
 
         if result:

--- a/services/moddingway/postgres/create_tables.sql
+++ b/services/moddingway/postgres/create_tables.sql
@@ -67,7 +67,7 @@ CREATE TABLE IF NOT EXISTS roles (
 CREATE TABLE IF NOT EXISTS forms (
 	formID INT GENERATED ALWAYS AS IDENTITY,
 	userID INT NOT null,
-	reason TEXT,
+	reason VARCHAR(1024),
 	approvalNotes TEXT,
 	approval BOOL,
 	approvedByUserID INT,


### PR DESCRIPTION
## Description

Updated DB reason field in forms table to varchar 1024 datatype. Updated submit form function in banforms route to check if reason text exceeds 1024 characters. 

Resolves backend portion of 

Ticket #21 

## Type of Change

Bug fix, data update to avoid issue with not pinging mods when appeal is sent. 

## Testing

Rebuilt database and confirmed new datatype. Testing route check is blocked by implementation of front-end ban appeal. 

## Checklist

- [X] Self-reviewed
- [X] Documentation updated (N/A)
