### PR TITLE
ci: fix and expand ticket validation regex

### DIFF
--- a/.github/workflows/pipeline-ticket.yml
+++ b/.github/workflows/pipeline-ticket.yml
@@ -32,7 +32,7 @@ jobs:
           CONTENT=$(printf "%s\n%s" "$PR_TITLE" "$PR_BODY")
 
           # Ticket pattern regex
-          REGEX='^[[:space:]]*(ticket[: ]+([0-9]+|NA)|(fix(es|ed|ing)?|clos(e[ds]?|ing)|resolv(e[ds]?|ing)|ref(s)?)[[:space:]]+#?[0-9]+|chore\(deps\)|chore\(release\)|\bNA\b)'
+          REGEX='^[[:space:]]*(ticket[: ]+#?([0-9]+|NA)|(fix(es|ed|ing)?|clos(e[ds]?|ing)|resolv(e[ds]?|ing)|ref(s)?)[[:space:]]+#?([0-9]+|NA)|chore\(deps\)|chore\(release\)|\bNA\b)'
 
           if echo "$CONTENT" | grep -qiE "$REGEX"; then
             MATCH=$(echo "$CONTENT" | grep -oiE "$REGEX" | head -n 1 | xargs)


### PR DESCRIPTION
## Description

Updates the CI ticket validation regex to resolve a failure where the `#` symbol was causing valid references to be rejected. It also expands the regex to support more common dev patterns requested by @a1icja.

Ticket NA

## Type of Change

Bug fix 

## Testing

Tested locally with a script to check the regex with multiple edge cases