### PR TITLE
ci: fix moddingway lint failure and pin tool versions

### DIFF
--- a/.github/workflows/pipeline-python.yml
+++ b/.github/workflows/pipeline-python.yml
@@ -34,7 +34,7 @@ jobs:
         uses: ./.github/actions/setup-matchers
 
       - name: Install Linting Tools
-        run: pip install ruff
+        run: pip install ruff==0.15.0
 
       - name: Ruff Format
         if: matrix.check == 'format'
@@ -43,7 +43,7 @@ jobs:
           service: ${{ inputs.service }}
           step-number: 10
           step-name: "Ruff Format"
-          command: ruff format --check .
+          command: ruff format --check --output-format=github --preview .
           output-file: format.txt
           working-directory: services/${{ inputs.service }}
 
@@ -87,7 +87,7 @@ jobs:
           service: ${{ inputs.service }}
           step-number: 20
           step-name: "Type Check"
-          command: ty check --output-format=github .
+          command: ty check --output-format=github --python=.venv .
           working-directory: services/${{ inputs.service }}
           fail-on-error: false
 

--- a/services/moddingway/moddingway_api/utils/paginate.py
+++ b/services/moddingway/moddingway_api/utils/paginate.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Sequence
-from typing import Any, TypeVar
+from typing import Any
 
 from fastapi_pagination.api import create_page
 from fastapi_pagination.utils import verify_params
@@ -12,10 +12,7 @@ def parse_pagination_params() -> tuple[int, int]:
     return (params.page, params.size)
 
 
-T = TypeVar("T")
-
-
-def paginate(
+def paginate[T](
     sequence: Sequence[T], length_function: Callable[[Sequence[T]], int]
 ) -> Any:
     params: Any

--- a/services/moddingway/requirements-dev.txt
+++ b/services/moddingway/requirements-dev.txt
@@ -4,5 +4,5 @@ pytest-cov
 pytest-mock
 pytest-asyncio
 ruff==0.15.0
-ty
+ty==0.0.11
 mypy


### PR DESCRIPTION
## Description

This PR resolves a CI failure triggered by the release of Ruff 0.15.1. 

Ticket NA

## Type of Change

Bug fix / CI Improvement

## Testing

Ruff/Ty: Verified that the new PEP 695 syntax passes all checks locally.
CI Pinning: Manually verified tool versions in the workflow.

## Checklist

- [x] Self-reviewed
- [x] Documentation updated
- [ ] Tests added/pass
