### PR TITLE
ci: correctly capture command exit code in report action

### DIFF
--- a/services/moddingway/moddingway/database/connection.py
+++ b/services/moddingway/moddingway/database/connection.py
@@ -53,6 +53,3 @@ class DatabaseConnection:
         if self._connection.closed:
             self.connect()
         return self._connection.cursor()
-
-
-db: int = DatabaseConnection()


### PR DESCRIPTION
## Description
Tracked down a sneaky bug where any step with `fail-on-error: false` was always showing as `success` in the CI report, even when the command actually failed. This meant `ty check` warnings in moddingway were silently swallowed and never showed up in the PR comment.

Ticket NA

## Type of Change
Bug fix

## Root Cause
Two issues were found and fixed:

**Issue 1:** The original code piped the command into `tee` and checked if the whole pipeline failed -- but since `tee` almost never exits non-zero, failures were silently masked:
```bash
if ! (set -e; ${{ inputs.command }}) 2>&1 | tee ${{ inputs.output-file }}; then
```
Fixed by capturing the command's exit code via `PIPESTATUS[0]`.

**Issue 2:** Adding `|| true` to prevent `set -e` from killing the script also reset `PIPESTATUS`, so the exit code was always 0. Fixed by using `set +e` instead, which disables exit-on-error without affecting `PIPESTATUS`.

## Testing
Verified by introducing a type error in this PR. 

## Checklist
- [x] Self-reviewed
- [ ] Documentation updated
- [x] Tests added/pass