### PR TITLE
ci: improve workflow path triggers and fix security scan matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,36 @@ jobs:
         id: filter
         with:
           filters: |
-            naurffxiv   : ['services/naurffxiv/**']
-            moddingway  : ['services/moddingway/**']
-            findingway  : ['services/findingway/**']
-            clearingway : ['services/clearingway/**']
-            authingway  : ['services/authingway/**']
-            apphost     : ['services/apphost/**']
+            _ci: &ci
+              - '.github/workflows/ci.yml'
+            naurffxiv:
+              - *ci
+              - 'services/naurffxiv/**'
+              - '.github/workflows/pipeline-node.yml'
+              - '.github/workflows/deploy-pr-netlify.yml'
+              - '.github/workflows/deploy-netlify.yml'
+            moddingway:
+              - *ci
+              - 'services/moddingway/**'
+              - '.github/workflows/pipeline-python.yml'
+            findingway:
+              - *ci
+              - 'services/findingway/**'
+              - '.github/workflows/pipeline-go.yml'
+            clearingway:
+              - *ci
+              - 'services/clearingway/**'
+              - '.github/workflows/pipeline-go.yml'
+            authingway:
+              - *ci
+              - 'services/authingway/**'
+              - '.github/workflows/pipeline-dotnet.yml'
+            apphost:
+              - *ci
+              - 'services/apphost/**'
+              - '.github/workflows/pipeline-dotnet.yml'
             e2e_required:
+              - *ci
               - 'services/naurffxiv/src/app/api/**'
               - 'services/moddingway/moddingway_api/**'
               - 'services/authingway/**'
@@ -49,6 +72,7 @@ jobs:
               - '**/*.csproj'
               - '**/Dockerfile'
               - 'tests/e2e/**'
+              - '.github/workflows/pipeline-e2e.yml'
 
       - name: Check E2E Status
         id: e2e-check

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           filters: |
             workflow:
-              - '.github/workflows/security.yml'
+              - '.github/workflows/**'
             naurffxiv:
               - 'services/naurffxiv/**'
               - 'tests/naurffxiv/**'
@@ -103,8 +103,16 @@ jobs:
           fi
 
           # Output Matrices
-          echo "languages=$(printf '%s\n' "${languages[@]}" | jq -R . | jq -s -c .)" >> $GITHUB_OUTPUT
-          echo "services=$(printf '%s\n' "${services[@]}" | jq -R . | jq -s -c .)" >> $GITHUB_OUTPUT
+          if [ ${#languages[@]} -eq 0 ]; then
+            echo "languages=[]" >> $GITHUB_OUTPUT
+          else
+            echo "languages=$(printf '%s\n' "${languages[@]}" | jq -R . | jq -s -c .)" >> $GITHUB_OUTPUT
+          fi
+          if [ ${#services[@]} -eq 0 ]; then
+            echo "services=[]" >> $GITHUB_OUTPUT
+          else
+            echo "services=$(printf '%s\n' "${services[@]}" | jq -R . | jq -s -c .)" >> $GITHUB_OUTPUT
+          fi
 
   secret-scan:
     name: Secret Scanning (Gitleaks)


### PR DESCRIPTION
## Description

Extends the `dorny/paths-filter` service change detection in `ci.yml` to also watch the workflow files that each service depends on. Previously, changes to a pipeline definition (e.g. `pipeline-node.yml`) would not trigger CI for the affected service. 

Additionally, fixes a CodeQL matrix bug in `security.yml` by broadening the workflow filter to `.github/workflows/**` to ensure any workflow change triggers a full scan. 

It also resolves a bash array bug where an empty array produced `[""]` instead of `[]`, which previously caused `CodeQL Analysis ()` to fail with an empty language on PRs without service changes.

Ticket NA

## Type of Change

CI / infrastructure

## Testing

- Path filter and CodeQL matrix correctness is validated on the next PR that modifies a workflow file.

## Checklist

- [x] Self-reviewed
- [ ] Documentation updated
- [ ] Tests added/pass