### PR TITLE
Increase discordMessageLink length in sql scheme to 40

### DIFF
--- a/services/moddingway/postgres/create_tables.sql
+++ b/services/moddingway/postgres/create_tables.sql
@@ -79,7 +79,7 @@ CREATE TABLE IF NOT EXISTS forms (
 
 CREATE TABLE IF NOT EXISTS announcements (
 	announcementID INT GENERATED ALWAYS AS IDENTITY,
-	discordMessageLink VARCHAR(20),
+	discordMessageLink VARCHAR(40),
 	announcementRevisions JSONB NOT NULL, --holds the last 3 revisions, version number and editor of the announcements [{“version”:x, “content”:”Announcement goes here.”, “author_id”: xxxxxxxxxxxx}]
 	sentFLAG BOOL NOT NULL DEFAULT FALSE,
 	PRIMARY KEY(announcementID)


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

<!-- Link a ticket: "Ticket #123", "Fixes #123", "Closes #123", "Resolves #123", or "Ticket NA" if none -->
Closes #159 

## Type of Change

<!-- Bug fix? New feature? Breaking change? Documentation? -->

## Testing

<!-- How did you test this? -->

<!--
## Screenshots
Add screenshots if applicable
-->

## Checklist

- [ ] Self-reviewed
- [ ] Documentation updated
- [ ] Tests added/pass
