### PR TITLE
fix(ci): use app token for QA team assignment

### DIFF
--- a/.github/actions/request-qa-review/index.js
+++ b/.github/actions/request-qa-review/index.js
@@ -25,7 +25,7 @@ module.exports = async ({ github, context, core }) => {
         `Requested review from @${context.repo.owner}/${shared.QA_TEAM_SLUG}.`,
       );
     } catch (err) {
-      console.warn("Could not request QA team review:", err.message);
+      throw new Error(`Could not request QA team review: ${err.message}`);
     }
   } catch (error) {
     console.error("Request QA Review Error:", error);

--- a/.github/workflows/qa-checklist.yml
+++ b/.github/workflows/qa-checklist.yml
@@ -56,10 +56,17 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - name: Request QA Team Review
         uses: ./.github/actions/request-qa-review
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           qa-team-slug: ${{ vars.QA_TEAM_SLUG || 'qa' }}
 
   check-qa-approval:


### PR DESCRIPTION
## Description

Use the GitHub App token when requesting QA team review on approval. `GITHUB_TOKEN` lacks org scope to resolve team nodes, causing assignment to silently fail. Also surfaces the error properly instead of swallowing it.

### Related Ticket

Closes #NA

## Type of Change

Bug fix

## Testing

Manually reviewed the Actions logs from the [previous failure](https://github.com/naurffxiv/naur/actions/runs/23988034952/job/69963107889?pr=243#step:3:23). Will verify on the next PR approval with Needs QA checked.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] Tests added and passing (if applicable)
- [ ] Needs QA
