### PR TITLE
 feat(moddingway): add last edited field to notes output 

### DIFF
--- a/services/moddingway/moddingway/database/notes_database.py
+++ b/services/moddingway/moddingway/database/notes_database.py
@@ -12,6 +12,7 @@ class NoteDisplay:
     content: str
     created_by: int
     last_editor: int
+    last_edited_timestamp: datetime
 
 
 def convert_row_to_note_display(row: tuple) -> NoteDisplay:
@@ -22,6 +23,7 @@ def convert_row_to_note_display(row: tuple) -> NoteDisplay:
             content=row[2],
             created_by=row[3],
             last_editor=row[4],
+            last_edited_timestamp=row[5],
         )
     except IndexError as e:
         raise ValueError(
@@ -65,7 +67,7 @@ def list_notes(user_id: int) -> list[NoteDisplay]:
 
     with conn.get_cursor() as cursor:
         query = """
-        select n.noteid, n.isWarning, n.note, n.createdby, n.lastEditedBy
+        select n.noteid, n.isWarning, n.note, n.createdby, n.lastEditedBy, n.lastEditedTimestamp
         from notes n
         join users u on u.userID = n.userID
         where u.userId = %s
@@ -85,7 +87,7 @@ def get_note(note_id: int) -> NoteDisplay:
 
     with conn.get_cursor() as cursor:
         query = """
-        select n.noteid, n.isWarning, n.note, n.createdby , n.lastEditedBy
+        select n.noteid, n.isWarning, n.note, n.createdby, n.lastEditedBy, n.lastEditedTimestamp
         from notes n
         join users u on u.userID = n.userID
         where n.noteid = %s
@@ -142,7 +144,7 @@ def list_warnings(user_id: int) -> list[NoteDisplay]:
 
     with conn.get_cursor() as cursor:
         query = """
-        select n.noteid, n.isWarning, n.note, n.createdby, n.lastEditedBy
+        select n.noteid, n.isWarning, n.note, n.createdby, n.lastEditedBy, n.lastEditedTimestamp
         from notes n
         join users u on u.userID = n.userID
         where u.userId = %s and n.isWarning = true

--- a/services/moddingway/moddingway/services/note_service.py
+++ b/services/moddingway/moddingway/services/note_service.py
@@ -5,7 +5,12 @@ import discord
 
 from moddingway.database import notes_database, users_database
 from moddingway.database.models import Note
-from moddingway.util import log_info_and_add_field, log_info_and_embed, send_dm
+from moddingway.util import (
+    log_info_and_add_field,
+    log_info_and_embed,
+    send_dm,
+    timestamp_to_epoch,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +71,8 @@ async def get_note_by_id(
         db_note.content = (
             f"[warning] {db_note.content}" if db_note.is_warning else db_note.content
         )
-        return f"\n* ID: {db_note.note_id} | Note: {db_note.content} | Note Creator: <@{db_note.created_by}> | Last Editor: <@{db_note.last_editor}>"
+        last_edited_epoch = timestamp_to_epoch(db_note.last_edited_timestamp)
+        return f"\n* ID: {db_note.note_id} | Note: {db_note.content} | Note Creator: <@{db_note.created_by}> | Last Editor: <@{db_note.last_editor}> | Last Edited: <t:{last_edited_epoch}:f>"
     else:
         return "Note not found"
 
@@ -88,9 +94,10 @@ async def get_user_notes(
         # Add [warning] prefix if it's a warning
         note_content = f"[warning] {note.content}" if note.is_warning else note.content
 
+        last_edited_epoch = timestamp_to_epoch(note.last_edited_timestamp)
         result = (
             result
-            + f"\n* ID: {note.note_id} | Note Creator: <@{note.created_by}> | Last Editor: <@{note.last_editor}> | Note: {note_content}"
+            + f"\n* ID: {note.note_id} | Note Creator: <@{note.created_by}> | Last Editor: <@{note.last_editor}> | Last Edited: <t:{last_edited_epoch}:f> | Note: {note_content}"
         )
 
     return result
@@ -112,9 +119,10 @@ async def get_user_warnings(
         # Add [warning] prefix if it's a warning
         note_content = f"[warning] {note.content}" if note.is_warning else note.content
 
+        last_edited_epoch = timestamp_to_epoch(note.last_edited_timestamp)
         result = (
             result
-            + f"\n* ID: {note.note_id} | Note Creator: <@{note.created_by}> | Last Editor: <@{note.last_editor}> | Note: {note_content}"
+            + f"\n* ID: {note.note_id} | Note Creator: <@{note.created_by}> | Last Editor: <@{note.last_editor}> | Last Edited: <t:{last_edited_epoch}:f> | Note: {note_content}"
         )
 
     return result

--- a/tests/moddingway/unit/services/test_note_service.py
+++ b/tests/moddingway/unit/services/test_note_service.py
@@ -1,0 +1,77 @@
+import datetime
+
+import pytest
+from pytest_mock.plugin import MockerFixture
+
+from moddingway.database.notes_database import NoteDisplay
+from moddingway.services import note_service
+
+DEFAULT_LAST_EDITED = datetime.datetime(2024, 6, 15, 12, 0, 0)
+DEFAULT_LAST_EDITED_EPOCH = int(
+    DEFAULT_LAST_EDITED.replace(tzinfo=datetime.UTC).timestamp()
+)
+
+
+@pytest.mark.asyncio
+async def test_get_user_notes__plain_note_includes_last_edited_timestamp(
+    mocker: MockerFixture, create_member, create_db_user
+):
+    # Arrange
+    user = create_member(id=999)
+    note = NoteDisplay(
+        note_id=7,
+        is_warning=False,
+        content="be nice",
+        created_by=111,
+        last_editor=222,
+        last_edited_timestamp=DEFAULT_LAST_EDITED,
+    )
+    mocker.patch(
+        "moddingway.database.users_database.get_user",
+        return_value=create_db_user(user_id=42),
+    )
+    mocker.patch(
+        "moddingway.database.notes_database.list_notes",
+        return_value=[note],
+    )
+
+    # Act
+    result = await note_service.get_user_notes(user)
+
+    # Assert
+    assert "ID: 7" in result
+    assert "Note Creator: <@111>" in result
+    assert "Last Editor: <@222>" in result
+    assert f"Last Edited: <t:{DEFAULT_LAST_EDITED_EPOCH}:f>" in result
+    assert "Note: be nice" in result
+    assert "[warning]" not in result
+
+
+@pytest.mark.asyncio
+async def test_get_note_by_id__plain_note_includes_last_edited_timestamp(
+    mocker: MockerFixture,
+):
+    # Arrange
+    note = NoteDisplay(
+        note_id=5,
+        is_warning=False,
+        content="a plain note",
+        created_by=111,
+        last_editor=222,
+        last_edited_timestamp=DEFAULT_LAST_EDITED,
+    )
+    mocker.patch(
+        "moddingway.database.notes_database.get_note",
+        return_value=note,
+    )
+
+    # Act
+    result = await note_service.get_note_by_id(5)
+
+    # Assert
+    assert "ID: 5" in result
+    assert "Note: a plain note" in result
+    assert "Note Creator: <@111>" in result
+    assert "Last Editor: <@222>" in result
+    assert f"Last Edited: <t:{DEFAULT_LAST_EDITED_EPOCH}:f>" in result
+    assert "[warning]" not in result


### PR DESCRIPTION
## Description

Does what it says on the tin - adds a "Last Edited" timestamp (formatted by Discord) to commands that are related to notes. This includes:
- `/view_notes`
- `/delete_note` - the confirmation box
- `/view_warnings` - pretty much a note

### Screenshots!

`/view_notes` output:

<img width="613" height="177" alt="screenshot_2026-04-05-144820" src="https://github.com/user-attachments/assets/9223f418-4856-4d8b-8fd7-52fdb2af9cd0" />

`/delete_note` output:

<img width="616" height="214" alt="screenshot_2026-04-05-144829" src="https://github.com/user-attachments/assets/5cec11f5-d737-456d-a8d7-e28283677871" />

`/view_warnings` output:

<img width="618" height="186" alt="screenshot_2026-04-05-144835" src="https://github.com/user-attachments/assets/0d8ed005-68cc-42d2-a7ce-76fd0dc6c44e" />

### Related Ticket

Closes #132.

## Type of Change

New feature.

## Testing

Added unit test file + manual testing.

## Checklist

- [X] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [X] Tests added and passing (if applicable)
- [x] Needs QA
