### PR TITLE
refactor: migrate Changelog components to TypeScript

### DIFF
--- a/services/naurffxiv/src/components/Changelog/ChangelogContent.tsx
+++ b/services/naurffxiv/src/components/Changelog/ChangelogContent.tsx
@@ -1,19 +1,22 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import Image from "next/image";
 import ReleaseCard from "@/components/Changelog/ReleaseCard";
 import { compareVersions } from "@/utils/compareVersions";
-import { fetchGithubReleases } from "@/utils/fetchGithubReleases";
+import {
+  fetchGithubReleases,
+  type GitHubRelease,
+} from "@/utils/fetchGithubReleases";
 
-export default function ChangelogContent() {
-  const [releases, setReleases] = useState([]);
-  const [expanded, setExpanded] = useState(null);
-  const [loading, setLoading] = useState(true);
+export default function ChangelogContent(): React.JSX.Element | null {
+  const [releases, setReleases] = useState<GitHubRelease[]>([]);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
-    const load = async () => {
+    const load = async (): Promise<void> => {
       try {
         const fetched = await fetchGithubReleases();
         fetched.sort(compareVersions);
@@ -30,11 +33,11 @@ export default function ChangelogContent() {
       }
     };
 
-    load();
+    void load();
     window.scrollTo(0, 0);
   }, []);
 
-  const toggleRelease = (version) => {
+  const toggleRelease = (version: string): void => {
     setExpanded((prev) => (prev === version ? null : version));
   };
 
@@ -72,11 +75,11 @@ export default function ChangelogContent() {
       <div className="space-y-8">
         {releases.map((release, idx) => (
           <ReleaseCard
-            key={release.id}
+            key={release["id"] as string}
             release={{
               version: release.tag_name,
-              date: release.published_at,
-              body: release.body,
+              date: release["published_at"] as string | null | undefined,
+              body: release["body"] as string | null | undefined,
             }}
             isExpanded={expanded === release.tag_name}
             toggleRelease={toggleRelease}

--- a/services/naurffxiv/src/components/Changelog/ReleaseCard.tsx
+++ b/services/naurffxiv/src/components/Changelog/ReleaseCard.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import React, { type ComponentPropsWithoutRef, useState } from "react";
+
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import { GH_REPO } from "@/utils/fetchGithubReleases";
 import ReactMarkdown from "react-markdown";
@@ -7,15 +9,27 @@ import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeHighlight from "rehype-highlight";
 import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
-import { useState } from "react";
+
+interface ReleaseData {
+  version: string;
+  date: string | null | undefined;
+  body: string | null | undefined;
+}
+
+interface ReleaseCardProps {
+  release: ReleaseData;
+  isExpanded: boolean;
+  toggleRelease: (version: string) => void;
+  isLatest: boolean;
+}
 
 export default function ReleaseCard({
   release,
   isExpanded,
   toggleRelease,
   isLatest,
-}) {
-  const [hovering, setHovering] = useState(false);
+}: ReleaseCardProps): React.JSX.Element | null {
+  const [hovering, setHovering] = useState<boolean>(false);
 
   if (!release?.version) return null;
 
@@ -39,7 +53,7 @@ export default function ReleaseCard({
       })
     : "";
 
-  const handleToggle = () => {
+  const handleToggle = (): void => {
     if (!isLatest) toggleRelease(release.version);
   };
 
@@ -63,7 +77,9 @@ export default function ReleaseCard({
               target="_blank"
               rel="noreferrer"
               className="text-4xl font-bold text-white hover:underline"
-              onClick={(e) => e.stopPropagation()} // Prevent expanding when clicking link
+              onClick={(e: React.MouseEvent<HTMLAnchorElement>) =>
+                e.stopPropagation()
+              } // Prevent expanding when clicking link
             >
               {release.version}
             </a>
@@ -119,16 +135,16 @@ export default function ReleaseCard({
                   rehypeHighlight,
                 ]}
                 components={{
-                  ul: (props) => (
+                  ul: (props: ComponentPropsWithoutRef<"ul">) => (
                     <ul {...props} className="space-y-2 text-gray-300" />
                   ),
-                  li: (props) => (
+                  li: (props: ComponentPropsWithoutRef<"li">) => (
                     <li {...props} className="flex gap-2 text-gray-300">
                       <span className="select-none">–</span>
                       <span>{props.children}</span>
                     </li>
                   ),
-                  h2: (props) => (
+                  h2: (props: ComponentPropsWithoutRef<"h2">) => (
                     <h2
                       {...props}
                       className="mt-8 mb-4 text-xl font-semibold text-white"


### PR DESCRIPTION
## Description

Converts `ChangelogContent` and `ReleaseCard` to TypeScript. No behaviour changes.

### Related Ticket

<!-- Examples: Fixes #123, Resolves #123, Closes #123, or Closes #NA -->

Closes #97 

## Type of Change

Tech debt / refactor

## Testing

- `tsc --noEmit` passes
- ESLint passes
- Dev server verified locally; changelog page loads, releases render, expand/collapse works correctly

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] Tests added and passing (if applicable)
- [ ] Needs QA

---

> [!IMPORTANT]
> Checking **Needs QA** triggers an automated checklist.
> Open in **Draft mode** so you can fill it out before requesting review.