### PR TITLE
feat(moddingway): include admin role in moderator check

### DIFF
--- a/services/moddingway/moddingway/util.py
+++ b/services/moddingway/moddingway/util.py
@@ -217,19 +217,21 @@ def calculate_time_delta(delta_string: str | None) -> timedelta | None:
 
 
 async def is_user_moderator(interaction: discord.Interaction):
-    if isinstance(interaction.user, discord.Member):
-        if user_has_role(interaction.user, Role.MOD):
-            return True
-        else:
-            raise discord.app_commands.MissingRole(Role.MOD)
+    if not isinstance(interaction.user, discord.Member):
+        return False
+    if user_has_role(interaction.user, Role.MOD) or user_has_role(
+        interaction.user, Role.ADMIN
+    ):
+        return True
+    raise discord.app_commands.MissingAnyRole([Role.MOD, Role.ADMIN])
 
 
 async def is_user_admin(interaction: discord.Interaction):
-    if isinstance(interaction.user, discord.Member):
-        if user_has_role(interaction.user, Role.ADMIN):
-            return True
-        else:
-            raise discord.app_commands.MissingRole(Role.ADMIN)
+    if not isinstance(interaction.user, discord.Member):
+        return False
+    if user_has_role(interaction.user, Role.ADMIN):
+        return True
+    raise discord.app_commands.MissingRole(Role.ADMIN)
 
 
 def timestamp_to_epoch(timestamp: datetime | None) -> int | None:

--- a/tests/moddingway/unit/conftest.py
+++ b/tests/moddingway/unit/conftest.py
@@ -36,6 +36,7 @@ def naur_guild(mocker: MockerFixture, create_role):
     return mocker.Mock(
         roles=[
             create_role(constants.Role.MOD),
+            create_role(constants.Role.ADMIN),
             create_role(constants.Role.VERIFIED),
             create_role(constants.Role.EXILED),
         ]
@@ -53,7 +54,7 @@ def create_member(mocker: MockerFixture, naur_guild, create_role):
             roles = [constants.Role.VERIFIED]
         role_list = [create_role(role) for role in roles]
         mocked_member = mocker.Mock(
-            spec=discord.member,
+            spec=discord.Member,
             guild=naur_guild,
             roles=role_list,
             id=id,

--- a/tests/moddingway/unit/test_util.py
+++ b/tests/moddingway/unit/test_util.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+import discord
 import pytest
 
 from moddingway import constants, util
@@ -90,3 +91,33 @@ async def test_add_and_remove_role(create_member):
 
     removed_role = mocked_member.remove_roles.call_args[0][0]
     assert removed_role.name == role_to_remove.value
+
+
+@pytest.mark.parametrize(
+    "input_roles,expected_result",
+    [
+        ([constants.Role.MOD], True),
+        ([constants.Role.ADMIN], True),
+        ([constants.Role.MOD, constants.Role.ADMIN], True),
+        ([constants.Role.VERIFIED], False),
+        ([], False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_is_user_moderator(
+    mocker,
+    create_member,
+    input_roles: list[constants.Role],
+    expected_result: bool,
+):
+    mocked_member = create_member(roles=input_roles)
+
+    mocked_interaction = mocker.Mock(spec=discord.Interaction)
+    mocked_interaction.user = mocked_member
+
+    if expected_result:
+        result = await util.is_user_moderator(mocked_interaction)
+        assert result is True
+    else:
+        with pytest.raises(discord.app_commands.MissingAnyRole):
+            await util.is_user_moderator(mocked_interaction)


### PR DESCRIPTION
## Description

Admins should be able to use mod commands without also needing the Mod role, this adds `Role.ADMIN` to the `is_user_moderator` check so that's the case now.

Also updated the error message when the check fails to say both roles are accepted (was only saying Mod before), and fixed a bug in the test fixture where the wrong Discord spec was being used, which was silently breaking `isinstance` checks in tests.

### Related Ticket

Closes #9

## Type of Change

New feature

## Testing

Added unit tests covering Admin-only, Mod-only, and both roles together. All 40 tests pass.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] Tests added and passing (if applicable)
- [x] Needs QA

---

> [!IMPORTANT]
> Checking **Needs QA** triggers an automated checklist.
> Open in **Draft mode** so you can fill it out before requesting review.
