### PR TITLE
content: Fill in the main page for The Unmaking (Extreme)

### DIFF
--- a/services/naurffxiv/src/components/Mdx/Layout/MdxComponents.js
+++ b/services/naurffxiv/src/components/Mdx/Layout/MdxComponents.js
@@ -11,6 +11,7 @@ import TwitchClip from "../Elements/Video/TwitchClip";
 import TwitchVoD from "../Elements/Video/TwitchVoD";
 import UnderConstruction from "../Elements/UnderConstruction.js";
 import YouTube from "../Elements/Video/YouTube";
+import OpenInNew from "@mui/icons-material/OpenInNew";
 
 export default function MDXComponents(mdxDir, lastUpdated) {
   // NB: We track the first H1 to ensure <LastUpdated /> only renders once,
@@ -53,5 +54,6 @@ export default function MDXComponents(mdxDir, lastUpdated) {
     UnderConstruction,
     Callout,
     Details,
+    OpenInNew,
   };
 }

--- a/services/naurffxiv/src/markdown/extreme/the-unmaking.mdx
+++ b/services/naurffxiv/src/markdown/extreme/the-unmaking.mdx
@@ -8,24 +8,72 @@ collapseToc: true
 
 <Banner src="/images/thumbnails/Hidden.avif" alt="The Unmaking" />
 
-#
+## Party Finder Summary
 
-# This page is under construction.
+```
+Hector | CC → CC
+OR
+Hector | CC → CCW
+```
 
-Check out our <a href="https://discord.com/invite/naurffxiv" className="text-blue-500 underline">Discord</a> for the latest strats.
+- **Hector**: Refers to the Hector guide below
+- **CC → CC** or **CC → CCW**: Refers to the direction that tethered players run
+  in the <mark className="hl-cast">Naught Hunts</mark> mechanic.
+  The first tethered players always run clockwise.
+  The second tethered players run CW or CCW depending on the strat.
 
-<img
-  src="/images/UnderConstructionMammet.avif"
-  alt="Under Construction Mammet"
-  style={{
-    position: "sticky",
-    bottom: "-40px",
-    left: "50%",
-    transform: "translateX(0%) translateY(0%)",
-    width: "100vw",
-    maxWidth: "450px",
-    height: "auto",
-    zIndex: 10,
-    pointerEvents: "none",
-  }}
-/>
+## [WTFDIG?<OpenInNew />](https://wtfdig.info/75/ex8)
+
+## Video Guides
+
+<Details title="Hector Hectorson | The Unmaking Extreme Guide">
+  <YouTube videoId="cA_WHJyXzyE" />
+</Details>
+
+<Details title="Kobe's Classroom | The Unmaking (Enuo) EXTREME Visual Guide">
+  <YouTube videoId="RfHB1qIqlSY" />
+
+This video uses strats similar to Hector's,
+except that the baits for <mark className="h1-cast">Airy/Dense Emptiness</mark>
+are on cardinals (i.e., DPS rotate)
+rather than intercardinals (i.e. supports rotate).
+
+</Details>
+
+## Raidplans
+
+<Details title="modified enuo">
+  The <a href="https://raidplan.io/plan/kgH6GJydOCbUs1L_#20">modified enuo</a> raidplan
+  was common on PF prior to the release of the Hector video.
+
+The strats are the same as the Hector video, except:
+
+- The baits for <mark className="hl-cast">Airy/Dense Emptiness</mark>
+  are on cardinals (i.e., DPS rotate)
+  rather than intercardinals (i.e. supports rotate).
+- During the intermission, rather than colour pairs,
+  TR always take northmost spots and HM always take southmost spots.
+  (This is sometimes referred to as "snake prio.")
+- <mark className="hl-cast">Naught Hunts</mark> is resolved CC → CCW.
+</Details>
+
+## [Timeline<OpenInNew />](https://docs.google.com/spreadsheets/d/1GclfG1rja7wFEDeGJ6frRiMscLwY3KRr81p5fdP0aV0/edit?gid=1938185007#gid=1938185007)
+
+## Markers
+
+<Details title="Standard clock spots">
+```json
+{
+    "Name":"Enuo EX",
+    "MapID":1116,
+    "A":{"X":100.0,"Y":0.0,"Z":87.0,"ID":0,"Active":true},
+    "B":{"X":113.0,"Y":0.0,"Z":100.0,"ID":1,"Active":true},
+    "C":{"X":100.0,"Y":0.0,"Z":113.0,"ID":2,"Active":true},
+    "D":{"X":87.0,"Y":0.0,"Z":100.0,"ID":3,"Active":true},
+    "One":{"X":90.808,"Y":0.0,"Z":90.808,"ID":4,"Active":true},
+    "Two":{"X":109.192,"Y":0.0,"Z":90.808,"ID":5,"Active":true},
+    "Three":{"X":109.192,"Y":0.0,"Z":109.192,"ID":6,"Active":true},
+    "Four":{"X":90.808,"Y":0.0,"Z":109.192,"ID":7,"Active":true}
+}
+```
+</Details>


### PR DESCRIPTION
## Description

This fills in the main page with links to current resources. PF seems to largely be using Hector strats so I have included them, but I have also included Kobe's video since it shows demonstrations of the mechanics in-game,
and the modified pastebin as it explains the CW->CCW tethers strat.

I've organized the page a little bit differently than other EX fights, prioritizing usability and
keeping the information most likely to be relevant at the top, as well as collapsing some information like waymarks behind zippies so that it's less annoying to I also imported used Material UI "external link" icon for links in
headers so that it's obvious they are links.

I don't currently have a banner image, so it's still a placeholder.

Ticket: NA

## Type of Change

Content update

## Testing

Verified it looks good in a local deploy

## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] Tests added and passing (if applicable)
- [ ] Needs QA