### PR TITLE
naurffxiv: Enable SELinux sharing for the dev build

### DIFF
--- a/services/naurffxiv/docker-compose.yml
+++ b/services/naurffxiv/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - .:/app/services/naurffxiv
+      - .:/app/services/naurffxiv:z
       - /app/services/naurffxiv/node_modules
       - /app/services/naurffxiv/.next
     environment:


### PR DESCRIPTION

## Description

Update SELinux policy of the naurffxiv dev build so that it works on a fresh setup.

See [the Docker
docs](https://docs.docker.com/engine/storage/bind-mounts/#configure-the-selinux-label) for explanation about the `:z` flag.

### Related Ticket

Fixes #320

## Type of Change

Dev build change

## Testing

Followed the reproduction steps in #320.

## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] Tests added and passing (if applicable)
- [ ] Needs QA

---

> [!IMPORTANT]
> Checking **Needs QA** triggers an automated checklist.
> Open in **Draft mode** so you can fill it out before requesting review.
