### PR TITLE
naurffxiv: Remove margin collapse suppression between headers.

### DIFF
--- a/services/naurffxiv/src/app/[difficulty]/[[...slug]]/mdx.css
+++ b/services/naurffxiv/src/app/[difficulty]/[[...slug]]/mdx.css
@@ -175,9 +175,3 @@ details[open] :last-child {
 .small-table .buff + .buff {
   padding-left: 5px;
 }
-
-/* contain margins to prevent "dead zones" between sections for the scrollspy */
-section {
-  padding-top: 0.1px;
-  padding-bottom: 0.1px;
-}


### PR DESCRIPTION
## Description

Removes the `section` styling rule which suppressed margin collapse between headers.

According to the code comment, this padding was added to suppress dead zones between margins. Some research showed me that this is a known issue with scrollspy implementations when the margins of sections were collapsed. However, in my local testing in Firefox 149 and Chrome 146, there was no issue with this rule removed, and the headers look much better. It's possible other browsers (Safari in particular?) may have an issue, but it's also possible this is just an issue that has been addressed in a more recent version of React's scrollspy.

### Related Ticket

Fixes #315.

## Type of Change

UI bug fix.

## Testing

Tested locally in Firefix 149 and Chrome 146.

## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] Tests added and passing (if applicable)
- [ ] Needs testing in Safari to ensure that scrollspy has no dead zones
- [x] Needs testing in Edge to ensure that scrollspy has no dead zones
- [x] Needs testing in Brave to ensure that scrollspy has no dead zones
- [x] Needs QA