### PR TITLE
content: Use <abbr> for abbreviations consistently in the FRU guide.

### DIFF
--- a/services/naurffxiv/next.config.mjs
+++ b/services/naurffxiv/next.config.mjs
@@ -7,13 +7,14 @@ import rehypeImgSize from "rehype-img-size";
 import rehypeSlug from "rehype-slug";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkToc from "remark-toc";
+import remarkGfm from "remark-gfm";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const withMDX = createMDX({
   extension: /\.mdx?$/,
   options: {
-    remarkPlugins: [remarkFrontmatter, remarkToc],
+    remarkPlugins: [remarkFrontmatter, remarkToc, remarkGfm],
     rehypePlugins: [
       rehypeSlug,
       [rehypeImgSize, { dir: "public" }],

--- a/services/naurffxiv/src/app/[difficulty]/[[...slug]]/helpers.js
+++ b/services/naurffxiv/src/app/[difficulty]/[[...slug]]/helpers.js
@@ -15,6 +15,7 @@ import rehypeSlug from "rehype-slug";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkMdxFrontmatter from "remark-mdx-frontmatter";
 import remarkSectionize from "remark-sectionize";
+import remarkGfm from "remark-gfm";
 import { reservedSlugs } from "@/config/constants";
 
 // process each mdx file and cache it
@@ -25,7 +26,12 @@ export const processMdx = cache(async (filepath) => {
   const processedMdx = await evaluate(rawmdx, {
     ...runtime,
     baseUrl: import.meta.url,
-    remarkPlugins: [remarkFrontmatter, remarkMdxFrontmatter, remarkSectionize],
+    remarkPlugins: [
+      remarkFrontmatter,
+      remarkMdxFrontmatter,
+      remarkSectionize,
+      remarkGfm,
+    ],
     rehypePlugins: [
       rehypeSlug,
       [

--- a/services/naurffxiv/src/app/[difficulty]/[[...slug]]/mdx.css
+++ b/services/naurffxiv/src/app/[difficulty]/[[...slug]]/mdx.css
@@ -158,20 +158,47 @@ details[open] :last-child {
 /* Small, condensed, MDX table */
 .small-table {
   width: fit-content !important;
-}
+  margin-block: 1em;
+  margin-inline-start: 1.6em;
 
-.small-table th,
-.small-table td {
-  padding: 2px 10px;
-  vertical-align: middle;
-}
+  /* If wrapping a table in a <div> to apply the class, remove extra margin. */
+  > table {
+    margin: 0;
+  }
 
-.small-table thead tr,
-.small-table tbody tr:nth-child(odd) {
-  background-color: rgba(0, 0, 0, 0.33);
-}
+  th,
+  td {
+    padding: 0.35em 0.8em;
+    vertical-align: middle;
+  }
 
-/* Give extra space to buffs immediately following other buffs */
-.small-table .buff + .buff {
-  padding-left: 5px;
+  thead tr,
+  tbody tr:nth-child(odd) {
+    background-color: rgba(0, 0, 0, 0.33);
+  }
+
+  /* Give extra space to buffs immediately following other buffs */
+  .buff + .buff {
+    padding-left: 5px;
+  }
+
+  td p {
+    margin: 0.4lh 0 !important;
+
+    &:first-child {
+      margin-top: 0 !important;
+    }
+
+    &:last-child {
+      margin-bottom: 0 !important;
+    }
+  }
+  &:has(td:has(:not(:only-child, :empty))) td:is(:only-child, :empty) {
+    margin-top: 0.1lh !important;
+    margin-bottom: 0.1lh !important;
+  }
+
+  th p {
+    margin: 0 !important;
+  }
 }

--- a/services/naurffxiv/src/markdown/ultimate/guide/fru/index.mdx
+++ b/services/naurffxiv/src/markdown/ultimate/guide/fru/index.mdx
@@ -12,9 +12,9 @@ collapseToc: true
   left
 />
 
-Welcome to NAUR's in-depth guide for Futures Rewritten (Ultimate).
+Welcome to NAUR's in-depth mechanics guide for Futures Rewritten (Ultimate).
 
-This guide will cover each phase in detail and provide tips to help you clear
+This guide covers each phase in detail and provide tips to help you clear
 and understand the fight, it will not explain different strats or mechanic
 solutions. As such, this guide should be used in tandem with other resources
 such as raidplans, powerpoints, or guide videos. Credit and thanks to Tvnariea Reksane
@@ -39,18 +39,14 @@ Before reading the guide, there are a couple things to note about the fight:
    [NAUR - Current FFXIV Ultimate BiS Sets](https://docs.google.com/spreadsheets/d/1V5HIN_yUxc-PIQQDv8zKkQ9TQNZ3OxQc66AxKIC_KaQ)
    spreadsheet for some example sets.
 
-3. To better utilize this guide, please refer to the resources found in the
-   [FRU resource page](/ultimate/fru). Many resources such as raidplans, mitigation plans,
-   cheat sheets, and more can be found there.
-
-4. It should also be noted that if a player fails a mechanic in this fight, they will often
+3. It should also be noted that if a player fails a mechanic in this fight, they will often
    receive a "**Damage Down**".
 
    > The "**Damage Down**" debuff in FRU will reduce the damage dealt by the player by 90% for 2 minutes.
-   > In most cases, it is recommended for players to die when they receive this debuff as the
+   > In most cases, it is recommended for players to intentionally die when they receive this debuff as the
    > "**Weakness**" debuff is shorter and reduces less damage. This is not always the case as some
-   > mechanics will require you to stay alive to resolve them but good to keep in mind.
+   > mechanics will require you to stay alive to resolve them; use your judgment to sacrifice at the first
+   > safe opportunity.
 
-5. All phases and major mechanics follow the Raidplans and Toolboxes found in the
-   [FRU resource page](/ultimate/fru). These links are also attached to the respective phase or mechanic headings.
-   If a heading is underlined with a hyperlink, it will take you to the respective toolbox or raidplan.
+4. This guide does not provide strats, mitigation plans, etc.
+   Please see the [FRU resource page](/ultimate/fru) for these resources.

--- a/services/naurffxiv/src/markdown/ultimate/guide/fru/p1_guide.mdx
+++ b/services/naurffxiv/src/markdown/ultimate/guide/fru/p1_guide.mdx
@@ -11,10 +11,7 @@ The mechanics will be quite familiar if you’ve done E11S, although there are n
 To clear the phase, Fatebreaker must be defeated completely.
 
 This phase is largely uptime, with a single downtime mechanic.
-Unless otherwise noted, any attack other than a spread, stack, raidwide, or tankbuster inflicts a
-
-<Buff b="damage-down" dur="2m" />, and all spreads and stacks inflict a
-<Buff b="magic-vuln" dur="2s" />.
+Unless otherwise noted, any attack other than a spread, stack, raidwide, or tankbuster inflicts a <Buff b="damage-down" dur="2m" />, and all spreads and stacks inflict a <Buff b="magic-vuln" dur="2s" />.
 
 ## Sequence 1: Cyclonic Break
 
@@ -23,7 +20,7 @@ During this cast, he will be surrounded by either <mark className="hl-fire">fire
 This will determine whether you need to <mark className="hl-fire">stack</mark> in pairs or <mark className="hl-electric">spread</mark> during the mechanic.
 There are different audio cues for the two elements: <mark className="hl-fire">fire</mark> is accompanied by a whooshing sound and <mark className="hl-electric">lightning</mark> by crackling.
 
-The attack executes a narrow (22.5°) conal spread targeting each player, without an <u title="A puddle telegraphing an upcoming AoE">omen</u>.
+The attack executes a narrow (22.5°) conal spread targeting each player, without an <abbr title="A puddle or marker telegraphing an upcoming attack.">omen</abbr>.
 These inflict <Buff b="phys-vuln" dur="2s" />, so any player hit by two or more will die.
 The location of these cones is saved and will be used for the rest of the mechanic.
 

--- a/services/naurffxiv/src/markdown/ultimate/guide/fru/p2_guide.mdx
+++ b/services/naurffxiv/src/markdown/ultimate/guide/fru/p2_guide.mdx
@@ -41,43 +41,42 @@ Three different things happen in rapid succession:
 
 1. It wouldn’t be a Shiva fight without the classic circular AoEs around the outside of the arena.
 2. The Oracle's Reflection begins casting either <mark className="hl-light">Axe Kick</mark> or <mark className="hl-light">Scythe Kick</mark>.
-3. Four players–all <mark className="hl-dps">DPS</mark> or all <mark className="hl-support">supports</mark>–are targeted by markers with a circular yellow omen.
+3. Four players–all <mark className="hl-dps">DPS</mark> or all <mark className="hl-support">supports</mark>–are targeted by markers with a circular yellow <abbr title="A puddle or marker telegraphing an upcoming attack.">omen</abbr>.
 
 All of these mechanics, and more, need to be solved simultaneously.
 
-1.  <span title="Puddle telegraphing an upcoming AoE">Omens</span> for the
-    classic circle AoEs—the true <mark className="hl-ice">Diamond Dust</mark>
-    —appear in the
-    <span title="Cardinals or intercardinals">principal directions</span>
-    in three waves. The first wave has two circles, appearing opposite one
-    another.
+1.  <abbr title="A puddle or marker telegraphing an upcoming attack.">Omens</abbr> for the classic circle AoEs—the true <mark className="hl-ice">Diamond Dust</mark>—appear in the <abbr title="Cardinals or intercardinals.">principal directions</abbr> in three waves.
+    The first wave has two circles, appearing opposite one another.
 
-        The second wave spreads out from the first wave: If the first wave was on a pair of cardinals, then the second wave will be on the four intercardinals.
+    The second wave spreads out from the first wave: If the first wave was on a pair of cardinals, then the second wave will be on the four intercardinals.
 
     Conversely, if the first wave was on intercardinals, then the second wave will be on the four cardinals.
 
-        The third wave will hit the two remaining cardinals or intercardinals, at 90° from the first wave.
+    The third wave will hit the two remaining cardinals or intercardinals, at 90° from the first wave.
 
     All three waves must be completely dodged.
 
 2.  The Oracle's Reflection’s cast will be either a point-blank (<mark className="hl-light">Axe Kick</mark>) or a donut (<mark className="hl-light">Scythe Kick</mark>).
-    These AoEs are very big: 1. The point-blank <mark className="hl-light">Axe Kick</mark> goes all the way out to the outer line/circle on the floor. 2. The donut <mark className="hl-light">Scythe Kick</mark> extends to well within the Reflection’s hitbox.
+    These AoEs are very big:
+    1. The point-blank <mark className="hl-light">Axe Kick</mark> goes all the way out to the outer line/circle on the floor.
+    2. The donut <mark className="hl-light">Scythe Kick</mark> extends to well within the Reflection’s hitbox.
+
     The safe area is only as wide as the small four-pointed star within the inner circle.
 
-        The two attacks can be distinguished by her voice line: <mark className="hl-light">Axe Kick</mark> is accompanied by “Cleave!”, and <mark className="hl-light">Scythe Kick</mark> by “Reap!”
+    The two attacks can be distinguished by her voice line: <mark className="hl-light">Axe Kick</mark> is accompanied by “Cleave!”, and <mark className="hl-light">Scythe Kick</mark> by “Reap!”
 
-        At the same time as the point-blank or donut, the Reflection also shoots out four <mark className="hl-light">The House of Light</mark> cones at the four nearest players.
+    At the same time as the point-blank or donut, the Reflection also shoots out four <mark className="hl-light">The House of Light</mark> cones at the four nearest players.
 
     These cones, combined with the four marker AoEs, create an 8-way spread.
 
 3.  The four circular markers go off moments after the kick, hitting their targets with <mark className="hl-ice">Frigid Stone</mark> at the same time as the first <mark className="hl-ice">Diamond Dust</mark> circles go off.
-    These drop a second set of AoEs, 8-way lines, with the omens appearing a few seconds after the <mark className="hl-ice">Frigid Stones</mark> hit.
+    These drop a second set of AoEs, 8-way lines, with the <abbr title="A puddle or marker telegraphing an upcoming attack.">omens</abbr> appearing a few seconds after the <mark className="hl-ice">Frigid Stones</mark> hit.
     These 8-way lines are similar to the ones during <mark className="hl-cast">Icelit Dragonsong</mark> in phase 2 of E8S.
 
 4.  The Oracle's Reflection moves out towards a principal direction and begins casting <mark className="hl-light">Sinbound Holy</mark>, while the Usurper of Frost reappears in the center of the arena.
     You will likely want to pay attention to the Reflection’s location, as it’s important later.
 
-        Without any warning, the Usurper performs <mark className="hl-ice">Heavenly Strike</mark>, a knockback raidwide, and disappears.
+    Without any warning, the Usurper performs <mark className="hl-ice">Heavenly Strike</mark>, a knockback raidwide, and disappears.
 
     This is the point where the second set of <mark className="hl-ice">Diamond Dust</mark> AoEs go off.
     You must get knocked back into a spot that’s safe from both the line AoEs and <mark className="hl-ice">Diamond Dust</mark>, with the final circles going off almost simultaneous with the lines.
@@ -140,7 +139,7 @@ Right afterwards, the two red mirrors cast <mark className="hl-light">Reflected 
 Unsurprisingly, this is the exact same move.
 But it must be solved so that none of the players clip each other.
 
-Each of the mirrors disappears shortly after
+Each of the mirrors disappears shortly after casting.
 
 ### Banish III
 
@@ -159,42 +158,15 @@ There’s a raidwide on this one, so make sure mits and shields are up.
 
 This mechanic makes use of the <Buff b="lightsteeped" /> debuff, given out by various attacks through the mechanic:
 
-<table className="small-table">
-  <thead>
-    <tr>
-      <th>Source</th>
-      <th>Total Stacks</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <mark className="hl-light">Light Rampant</mark>
-      </td>
-      <td>6</td>
-    </tr>
-    <tr>
-      <td>First wave towers</td>
-      <td>6</td>
-    </tr>
-    <tr>
-      <td>
-        <mark className="hl-light">Powerful Light</mark> stacks
-      </td>
-      <td>8</td>
-    </tr>
-    <tr>
-      <td>Second wave tower</td>
-      <td>4</td>
-    </tr>
-    <tr>
-      <td>
-        <mark className="hl-light">House of Light</mark> spread
-      </td>
-      <td>8</td>
-    </tr>
-  </tbody>
-</table>
+<div className="small-table">
+| Source | Total Stacks |
+| :----- | :----------: |
+| <mark className="hl-light">Light Rampant</mark> | 6 |
+| First wave towers | 6 |
+| <mark className="hl-light">Powerful Light</mark> stacks | 8 |
+| Second wave tower | 4 |
+| <mark className="hl-light">House of Light</mark> spread | 8 |
+</div>
 
 This is a total of 32 stacks, which is exactly enough to give 4 <Buff b="lightsteeped" short /> to every player.
 This is very convenient, because 5 <Buff b="lightsteeped" short /> causes a wipe.
@@ -203,7 +175,7 @@ Everyone must get exactly four stacks.
 The initial raidwide doles out several markers and debuffs.
 It is believed that these are given out completely at random, with no role-based patterns.
 
-- Two players receive a pink marker with a circular AoE omen.
+- Two players receive a pink marker with a circular AoE <abbr title="A puddle or marker telegraphing an upcoming attack.">omen</abbr>.
 
 - The remaining six players each receive <Buff b="chains-of-everlasting-light" dur="10s" />, visibly displaying as tethers connecting them to two other players.
   These tethers are not yet active.
@@ -239,11 +211,11 @@ Unlike in the original Light Rampant, for these tethers there is no maximum dist
 
 The six silver orbs that descended on the towers, Holy Lights, hover in place above the ground.
 
-Three of them, in an equilateral triangle, begin casting <mark className="hl-cast">Burst</mark> and display large circular omens.
+Three of them, in an equilateral triangle, begin casting <mark className="hl-cast">Burst</mark> and display large circular <abbr title="A puddle or marker telegraphing an upcoming attack.">omens</abbr>.
 The other three follow suit shortly after.
 This is very similar to the fists during the phase 4 transition of TOP, if you are familiar with that fight.
 
-As the second wave of omens appears, the <Buff b="the-weight-of-light" short /> detonate in a small circular AoE.
+As the second wave of <abbr title="A puddle or marker telegraphing an upcoming attack.">omens</abbr> appears, the <Buff b="the-weight-of-light" short /> detonate in a small circular AoE.
 This is <mark className="hl-light">Powerful Light</mark>, a LP stack that inflicts <Buff b="lightsteeped" short dur="36s" />.
 If fewer than 4 players are in the stack, it additionally inflicts <Buff b="mark-of-mortality" dur="2m" />.
 A 4-stack tower also appears in the center of the arena at the same time.

--- a/services/naurffxiv/src/markdown/ultimate/guide/fru/p4_guide.mdx
+++ b/services/naurffxiv/src/markdown/ultimate/guide/fru/p4_guide.mdx
@@ -200,7 +200,7 @@ The purple tethers will hit either the NW and SE hourglasses, or NE and SW.
 In other words, all three Hourglasses go off in opposite pairs, with north and south going off first.
 
 The cast from the Hourglasses in this mechanic is <mark className="hl-cast">Maelstrom</mark>, a circular AoE that covers the entire circle on the floor.
-There is a very brief omen, hardly enough to dodge.
+There is a very brief <abbr title="A puddle or marker telegraphing an upcoming attack.">omen</abbr>, hardly enough to dodge.
 
 The explosions happen concurrently with the Spell-in-Waiting debuffs resolving, towards the start of the mechanic.
 The hourglasses are completely inert after they explode.
@@ -277,8 +277,9 @@ The players are released from stun during the second knockback, and both bosses 
     <tr>
       <td>t + 3 s</td>
       <td>
-        <div>Drachen Wanderers appear</div>
-        <div>Shiva becomes untargetable</div>
+        Drachen Wanderers appear
+
+        Shiva becomes untargetable
       </td>
     </tr>
     <tr>
@@ -287,42 +288,36 @@ The players are released from stun during the second knockback, and both bosses 
     </tr>
     <tr>
       <td>t + 5 s</td>
-      <td>
-        <mark className="hl-cast">Edge of Oblivion</mark> raidwide
-      </td>
+      <td><mark className="hl-cast">Edge of Oblivion</mark> raidwide</td>
     </tr>
     <tr>
       <td>t + 10 s</td>
       <td>
-        <mark className="hl-cast">Malestrom</mark> omens from yellow-tethered
-        Hourglasses
+        <mark className="hl-cast">Malestrom</mark> <abbr title="A puddle or marker telegraphing an upcoming attack.">omens</abbr> from yellow-tethered Hourglasses
       </td>
     </tr>
     <tr>
       <td>t + 12 s</td>
       <td>
-        <Buff b="siw-dark-water" short /> stack and yellow-tethered{" "}
-        <mark className="hl-cast">Maelstroms</mark> go off
+        <Buff b="siw-dark-water" short /> stack and yellow-tethered <mark className="hl-cast">Maelstroms</mark> go off
       </td>
     </tr>
     <tr>
       <td>t + 14 s</td>
       <td>
-        <div>
-          <Buff b="siw-dark-eruption" short /> circle,{" "}
-          <Buff b="siw-dark-blizzard" short /> donut, and{" "}
+          <Buff b="siw-dark-eruption" short /> circle,
+          <Buff b="siw-dark-blizzard" short /> donut, and
           <Buff b="siw-dark-aero" short /> knockback go off
-        </div>
-        <div>
+
           Safe to cleanse <Buff b="wyrmclaw" short /> without breaking Fragment
-        </div>
       </td>
     </tr>
     <tr>
       <td>t + 15 s</td>
       <td>
-        <mark className="hl-cast">Maelstrom</mark> omens appear from
-        non-tethered Hourglasses
+        <mark className="hl-cast">Maelstrom</mark>
+        <abbr title="A puddle or marker telegraphing an upcoming attack.">omens</abbr>
+        appear from non-tethered Hourglasses
       </td>
     </tr>
     <tr>
@@ -332,44 +327,41 @@ The players are released from stun during the second knockback, and both bosses 
     <tr>
       <td>t + 17 s</td>
       <td>
-        <div>
-          <Buff b="siw-unholy-darkness" short /> stack and non-tethered{" "}
-          <mark className="hl-cast">Maelstroms</mark> go off
-        </div>
-        <div>East/west exaline omen appears</div>
-        <div>
-          <Buff b="wyrmclaw" dur="17" short /> kills if not cleansed by now
-        </div>
+        <Buff b="siw-unholy-darkness" short /> stack and non-tethered <mark className="hl-cast">Maelstroms</mark> go off
+
+        East/west exaline <abbr title="A puddle or marker telegraphing an upcoming attack.">omen</abbr> appears
+
+        <Buff b="wyrmclaw" dur="17" short /> kills if not cleansed by now
       </td>
     </tr>
     <tr>
       <td>t + 20 s</td>
       <td>
-        <div>
-          <mark className="hl-cast">Maelstrom</mark> omens from purple-tethered
-          Hourglasses
-        </div>
-        <div>East/west exalines begin, firing approx. every 2 seconds</div>
+        <mark className="hl-cast">Maelstrom</mark> <abbr title="A puddle or marker telegraphing an upcoming attack.">omens</abbr> appear from purple-tethered Hourglasses
+
+        East/west exalines begin, firing approx. every 2 seconds
       </td>
     </tr>
     <tr>
       <td>t + 22 s</td>
       <td>
-        <div>
-          Purple-tethered <mark className="hl-cast">Maelstroms</mark> go off
-        </div>
-        <div>Shiva teleports to north or south</div>
+        Purple-tethered <mark className="hl-cast">Maelstroms</mark> go off
+
+        Shiva teleports to north or south
       </td>
     </tr>
     <tr>
       <td>t + 24 s</td>
-      <td>North/south exaline omen appears</td>
+      <td>
+        North/south exaline <abbr title="A puddle or marker telegraphing an upcoming attack.">omen</abbr> appears
+      </td>
     </tr>
     <tr>
       <td>t + 27 s</td>
       <td>
-        <div>North/south exalines begin</div>
-        <div>East/west exalines end</div>
+        North/south exalines begin
+
+        East/west exalines end
       </td>
     </tr>
     <tr>
@@ -381,10 +373,9 @@ The players are released from stun during the second knockback, and both bosses 
     <tr>
       <td>t + 33 s</td>
       <td>
-        <div>
-          <Buff b="siw-return" short /> snapshots player positions
-        </div>
-        <div>North/south exalines end</div>
+        <Buff b="siw-return" short /> snapshots player positions
+
+        North/south exalines end
       </td>
     </tr>
     <tr>
@@ -396,12 +387,11 @@ The players are released from stun during the second knockback, and both bosses 
     <tr>
       <td>t + 40 s</td>
       <td>
-        <div>Players stunned and returned to snapshot positions</div>
-        <div>
-          <Buff b="wyrmclaw" dur="40" short /> and{" "}
-          <Buff b="wyrmfang" dur="40" short /> kill if not cleansed by now
-        </div>
-        <div>Drachen Wanderers wipe party if not destroyed by now</div>
+        Players stunned and returned to snapshot positions
+
+        <Buff b="wyrmclaw" dur="40" short /> and <Buff b="wyrmfang" dur="40" short /> kill if not cleansed by now
+
+        Drachen Wanderers wipe party if not destroyed by now
       </td>
     </tr>
     <tr>
@@ -419,8 +409,9 @@ The players are released from stun during the second knockback, and both bosses 
     <tr>
       <td>t + 52 s</td>
       <td>
-        <div>Bosses become targetable</div>
-        <div>Sequence complete</div>
+        Bosses become targetable
+
+        Sequence complete
       </td>
     </tr>
   </tbody>

--- a/services/naurffxiv/src/markdown/ultimate/guide/fru/p5_guide.mdx
+++ b/services/naurffxiv/src/markdown/ultimate/guide/fru/p5_guide.mdx
@@ -31,9 +31,9 @@ These are all exalines that detonate two at a time, moving outwards from their l
 Starting from one side of the 3/4-circle, the outermost two lines on one side will detonate, then the middle two, then finally the two on the other side.
 Each pair will be arranged so that the lines from the light and dark sides cross.
 
-Before each line explodes, an omen appears showing the upcoming explosion, with many arrows indicating that the line AoEs are going to move.
+Before each line explodes, an <abbr title="A puddle or marker telegraphing an upcoming attack.">omen</abbr> appears showing the upcoming explosion, with many arrows indicating that the line AoEs are going to move.
 The first two exalines go off, and then they repeat in the directions indicated, perpendicular to the original line they came from.
-There are no omens for the subsequent explosions.
+There are no <abbr title="A puddle or marker telegraphing an upcoming attack.">omens</abbr> for the subsequent explosions.
 
 The detonations go as follows:
 
@@ -50,7 +50,9 @@ The detonations go as follows:
   <tbody>
     <tr>
       <td>1.</td>
-      <td>Omens appear</td>
+      <td>
+        <abbr title="A puddle or marker telegraphing an upcoming attack.">Omens</abbr> appear
+      </td>
       <td></td>
       <td></td>
       <td></td>
@@ -65,7 +67,9 @@ The detonations go as follows:
     <tr>
       <td>3.</td>
       <td>2nd explosions</td>
-      <td>Omens appear</td>
+      <td>
+        <abbr title="A puddle or marker telegraphing an upcoming attack.">Omens</abbr> appear
+      </td>
       <td></td>
       <td></td>
     </tr>
@@ -80,7 +84,9 @@ The detonations go as follows:
       <td>5.</td>
       <td>4th explosions</td>
       <td>2nd explosions</td>
-      <td>Omens appear</td>
+      <td>
+        <abbr title="A puddle or marker telegraphing an upcoming attack.">Omens</abbr> appear
+      </td>
       <td>Lock direction</td>
     </tr>
     <tr>
@@ -105,14 +111,14 @@ The detonations go as follows:
       <td>Akh Morn …</td>
     </tr>
     <tr>
-      <td>8.</td>
+      <td>9.</td>
       <td>8th explosions</td>
       <td>6th explosions</td>
       <td>4th explosions</td>
       <td>Akh Morn …</td>
     </tr>
     <tr>
-      <td>8.</td>
+      <td>10.</td>
       <td></td>
       <td>7th explosions</td>
       <td>5th explosions</td>
@@ -163,12 +169,12 @@ The mechanic goes off in three waves: the first tower, wing, and tether; then th
 2.  The wing attack is a massive 225° tankbuster cleave that hits the entire quarter of the arena in front of Pandora, as well as the entire side of the corresponding wing.
     The safe zone is therefore anywhere beside or behind her and on the <mark className="hl-light">right</mark> or <mark className="hl-dark">left</mark> side, depending on the wing/element.
 
-        But immediately before she executes the cleave, she turns to face the main tank, (that is, the player with top enmity).
+    But immediately before she executes the cleave, she turns to face the main tank, (that is, the player with top enmity).
 
     So the safe zone is actually relative to this player.
     Anyone _other_ than the top enmity player hit by this attack will receive a <Buff b="damage-down" dur="2m" short />, so cheesing it is not an option.
 
-        Despite having a visual element, the cleave is physical and inflicts <Buff b="phys-vuln" dur="4" />.
+    Despite having a visual element, the cleave is physical and inflicts <Buff b="phys-vuln" dur="4" />.
 
     The <Buff b="phys-vuln" short /> makes the follow-up cleave lethal, but not the other attacks in the sequence.
     The target lock-in is typical for a tankbuster, with the first target getting locked in early in the cast, and the second locking in roughly when the castbar completes.
@@ -177,7 +183,7 @@ The mechanic goes off in three waves: the first tower, wing, and tether; then th
     The tether moves to whoever is <mark className="hl-light">farthest</mark> or <mark className="hl-dark">nearest</mark> automatically, just acting as a visual indication of who will be hit.
     It cannot be passed otherwise.
 
-        The actual attack is a small circular tankbuster that inflicts <Buff b="magic-vuln" dur="4s" short />.
+    The actual attack is a small circular tankbuster that inflicts <Buff b="magic-vuln" dur="4s" short />.
 
     Thus, like the wing cleave, the same player cannot take it twice without facing lethal damage, nor can they take a tower on the same or next wave.
     It is, however, possible for a player hit by the first tether to safely soak the last tower.


### PR DESCRIPTION
## Description

Use <abbr> for abbreviations consistently in the FRU guide.

Replaces existing inconsistent uses of `<u>` and `<span>`, and adds abbreviation highlights to every use of the word "omen".

Also has a drive-by fix for a formatting bug where Prettier split a paragraph into two incorrectly.

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] Tests added and passing (if applicable)
