### PR TITLE
ci: add CODEOWNERS to automatically route review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @naurffxiv/naur-developer
+*.mdx @naurffxiv/content-management


### PR DESCRIPTION
## Description

Configures a `.github/CODEOWNERS` file to automatically route pull request review requests to the appropriate teams based on the files modified:
- All files default to requesting a review from the `@naurffxiv/naur-developer` team.
- Content files (`*.mdx`) are specifically routed to the `@naurffxiv/content-management` team, preventing developers from being automatically pinged for content-only changes.

### Related Ticket

Closes #NA 

## Type of Change

CI / Configuration

## Testing

N/A - Configuration file.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] Tests added and passing (if applicable)
- [ ] Needs QA
