### PR TITLE
build(deps): bump uv to 0.11.14 and python-multipart to 0.0.28

### DIFF
--- a/.github/workflows/pipeline-python.yml
+++ b/.github/workflows/pipeline-python.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version: "0.10.4"
+          version: "0.11.14"
           enable-cache: true
           python-version: ${{ inputs.python-version }}
           cache-dependency-glob: "services/${{ inputs.service }}/uv.lock"
@@ -75,7 +75,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version: "0.10.4"
+          version: "0.11.14"
           enable-cache: true
           python-version: ${{ inputs.python-version }}
           cache-dependency-glob: "services/${{ inputs.service }}/uv.lock"
@@ -106,7 +106,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version: "0.10.4"
+          version: "0.11.14"
           enable-cache: true
           python-version: ${{ inputs.python-version }}
           cache-dependency-glob: "services/${{ inputs.service }}/uv.lock"

--- a/scripts/makefile/_config.ps1
+++ b/scripts/makefile/_config.ps1
@@ -51,7 +51,7 @@ $script:ServiceRegistry = @{
     }
 }
 
-$script:UvVersion = "0.10.4"
+$script:UvVersion = "0.11.14"
 
 $script:PackageManager = @{
     Name         = "pnpm"

--- a/services/moddingway/.pre-commit-config.yaml
+++ b/services/moddingway/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: end-of-file-fixer
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.10.4
+    rev: 0.11.14
     hooks:
       - id: uv-lock
       - id: uv-sync

--- a/services/moddingway/moddingway/Dockerfile
+++ b/services/moddingway/moddingway/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.14-slim
 
-COPY --from=ghcr.io/astral-sh/uv:0.10.4 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.14 /uv /uvx /bin/
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \

--- a/services/moddingway/pyproject.toml
+++ b/services/moddingway/pyproject.toml
@@ -70,4 +70,4 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 
 [tool.uv]
-required-version = "==0.10.4"
+required-version = "==0.11.14"

--- a/services/moddingway/uv.lock
+++ b/services/moddingway/uv.lock
@@ -878,11 +878,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

- Upgrades uv to 0.11.14 to meet Dependabot's minimum supported version
- Updates python-multipart to 0.0.28 in uv.lock to resolve Denial of Service vulnerability with unbounded multipart part headers

### Related Ticket

Closes #338

## Type of Change

Dep Upgrade, Security Fix

## Testing

make test and make sync

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] Tests added and passing (if applicable)
- [ ] Needs QA

---

> [!IMPORTANT]
> Checking **Needs QA** triggers an automated checklist.
> Open in **Draft mode** so you can fill it out before requesting review.
