### PR TITLE
chore(deps): update urllib3 to >=2.7.0 to fix CVE-2026-44431

### DIFF
--- a/services/moddingway/pyproject.toml
+++ b/services/moddingway/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "uvicorn==0.41.0",
     "fastapi-pagination==0.15.10",
     "python-dotenv==1.2.1",
+    "urllib3>=2.7.0",
 ]
 
 [dependency-groups]

--- a/services/moddingway/uv.lock
+++ b/services/moddingway/uv.lock
@@ -573,6 +573,7 @@ dependencies = [
     { name = "psycopg2" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "urllib3" },
     { name = "uvicorn" },
 ]
 
@@ -594,6 +595,7 @@ requires-dist = [
     { name = "psycopg2", specifier = "==2.9.11" },
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "python-dotenv", specifier = "==1.2.1" },
+    { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", specifier = "==0.41.0" },
 ]
 
@@ -1097,11 +1099,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Updates `urllib3` to `>=2.7.0` in the `moddingway` service dependencies to resolve a high-severity security vulnerability (CVE-2026-44431).

### Related Ticket

Closes #NA

## Type of Change

Security fix / Dependency update

## Testing

- Updated `pyproject.toml` and verified `uv.lock` successfully resolved with `urllib3` v2.7.0.
- Ran `uv lock` locally to ensure valid lockfile generation.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] Tests added and passing (if applicable)
- [ ] Needs QA

---

> [!IMPORTANT]
> Checking **Needs QA** triggers an automated checklist.
> Open in **Draft mode** so you can fill it out before requesting review.
