### PR TITLE
add Dancing Mad (Ultimate) placeholder guide and homepage card

### DIFF
--- a/services/naurffxiv/src/config/constants.ts
+++ b/services/naurffxiv/src/config/constants.ts
@@ -21,6 +21,12 @@ export const pages = [
 
 export const ultimateList = [
   {
+    title: "Dancing Mad",
+    url: "/ultimate/dmu",
+    img: "/images/thumbnails/Hidden.avif",
+    alt: "Dancing Mad",
+  },
+  {
     title: "Futures Rewritten",
     url: "/ultimate/fru",
     img: images.Pandora,

--- a/services/naurffxiv/src/markdown/ultimate/_meta.json
+++ b/services/naurffxiv/src/markdown/ultimate/_meta.json
@@ -1,4 +1,7 @@
 {
+  "dmu": {
+    "index": "dmu.mdx"
+  },
   "fru": {
     "index": "fru.mdx",
     "guide": {

--- a/services/naurffxiv/src/markdown/ultimate/dmu.mdx
+++ b/services/naurffxiv/src/markdown/ultimate/dmu.mdx
@@ -1,0 +1,30 @@
+---
+title: Dancing Mad (Ultimate)
+order: 0
+---
+
+# Dancing Mad (Ultimate)
+
+<Banner src="/images/thumbnails/Hidden.avif" alt="Dancing Mad (Ultimate)" />
+
+#
+
+# This page is under construction.
+
+Check out our <a href="https://discord.com/invite/naurffxiv" className="text-blue-500 underline">Discord</a> for the latest strats.
+
+<img
+  src="/images/UnderConstructionMammet.avif"
+  alt="Under Construction Mammet"
+  style={{
+    position: "sticky",
+    bottom: "-40px",
+    left: "50%",
+    transform: "translateX(0%) translateY(0%)",
+    width: "100vw",
+    maxWidth: "450px",
+    height: "auto",
+    zIndex: 10,
+    pointerEvents: "none",
+  }}
+/>

--- a/services/naurffxiv/src/markdown/ultimate/dsr.mdx
+++ b/services/naurffxiv/src/markdown/ultimate/dsr.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragonsong's Reprise (Ultimate)
-order: 2
+order: 3
 ---
 
 # Dragonsong's Reprise (Ultimate)

--- a/services/naurffxiv/src/markdown/ultimate/fru.mdx
+++ b/services/naurffxiv/src/markdown/ultimate/fru.mdx
@@ -1,6 +1,6 @@
 ---
 title: Futures Rewritten (Ultimate)
-order: 0
+order: 1
 ---
 
 # Futures Rewritten (Ultimate)

--- a/services/naurffxiv/src/markdown/ultimate/tea.mdx
+++ b/services/naurffxiv/src/markdown/ultimate/tea.mdx
@@ -1,6 +1,6 @@
 ---
 title: The Epic of Alexander (Ultimate)
-order: 3
+order: 4
 ---
 
 # The Epic of Alexander (Ultimate)

--- a/services/naurffxiv/src/markdown/ultimate/top.mdx
+++ b/services/naurffxiv/src/markdown/ultimate/top.mdx
@@ -1,6 +1,6 @@
 ---
 title: The Omega Protocol (Ultimate)
-order: 1
+order: 2
 ---
 
 # The Omega Protocol (Ultimate)

--- a/services/naurffxiv/src/markdown/ultimate/ucob.mdx
+++ b/services/naurffxiv/src/markdown/ultimate/ucob.mdx
@@ -1,6 +1,6 @@
 ---
 title: The Unending Coil of Bahamut (Ultimate)
-order: 5
+order: 6
 ---
 
 # The Unending Coil of Bahamut (Ultimate)

--- a/services/naurffxiv/src/markdown/ultimate/uwu.mdx
+++ b/services/naurffxiv/src/markdown/ultimate/uwu.mdx
@@ -1,6 +1,6 @@
 ---
 title: The Weapon's Refrain (Ultimate)
-order: 4
+order: 5
 ---
 
 # The Weapon's Refrain (Ultimate)


### PR DESCRIPTION
## Description

Adds the DMU placeholder and features it on the homepage and menus using the `Hidden.avif` spoiler image.

### Related Ticket

<!-- Examples: Fixes #123, Resolves #123, Closes #123, or Closes #NA -->

Closes #NA

## Type of Change

- New feature

## Testing

Tested on localhost to see if navigation worked.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] Tests added and passing (if applicable)
- [ ] Needs QA

---

> [!IMPORTANT]
> Checking **Needs QA** triggers an automated checklist.
> Open in **Draft mode** so you can fill it out before requesting review.
