### PR TITLE
Replace HighEndDuty with UMAD listings

### DIFF
--- a/services/findingway/config.yaml
+++ b/services/findingway/config.yaml
@@ -41,5 +41,5 @@ channels:
     dataCentres: [Aether, Crystal, Dynamis, Primal]
   - id: "1511412259895771237"
     name: "naur dancing mad check"
-    duty: "HighEndDuty"
+    duty: "Dancing Mad (Ultimate)"
     dataCentres: [Aether, Crystal, Dynamis, Primal]

--- a/services/findingway/internal/tokenizer/tokenizer.go
+++ b/services/findingway/internal/tokenizer/tokenizer.go
@@ -105,7 +105,7 @@ func (t *Tokenizer) TokenizeListings(listings *ffxiv.Listings) {
 	parsedListingIds := []string{}
 
 	scopedListings := listings.ForDutiesAndDataCentres(
-		[]string{"HighEndDuty", "Dancing Mad (Ultimate)"},
+		[]string{"Dancing Mad (Ultimate)"},
 		[]string{"Aether", "Crystal", "Dynamis", "Primal"})
 
 	for _, item := range scopedListings.Listings {


### PR DESCRIPTION
Ticket: #395

## Description

Replaces `HighEndDuty` with UMAD as xivpf changed their listings to the proper `Dancing Mad (Ultimate)`

### Related Ticket

Closes #395

## Type of Change

Bug fix

## Testing

i made these changes in prod and it works lol

## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] Tests added and passing (if applicable)
- [ ] Needs QA

---

> [!IMPORTANT]
> Checking **Needs QA** triggers an automated checklist.
> Open in **Draft mode** so you can fill it out before requesting review.
