### PR TITLE
feat(moddingway): add note on exhile excl roulette

### DIFF
--- a/services/moddingway/moddingway/Dockerfile
+++ b/services/moddingway/moddingway/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.14-slim
 COPY --from=ghcr.io/astral-sh/uv:0.11.14 /uv /uvx /bin/
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc \
+    build-essential \
     libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 

--- a/services/moddingway/moddingway/commands/exile_commands.py
+++ b/services/moddingway/moddingway/commands/exile_commands.py
@@ -81,7 +81,11 @@ class RouletteDeleteView(discord.ui.View):
                     response_message.set_string("Invalid exile duration.")
                     return
                 error_message = await exile_user(
-                    logging_embed, interaction.user, exile_duration, reason
+                    logging_embed,
+                    interaction.user,
+                    exile_duration,
+                    reason,
+                    add_note=False,
                 )
 
                 if error_message:
@@ -161,7 +165,11 @@ def create_exile_commands(bot: Bot) -> None:
                     response_message.set_string("Invalid exile duration.")
                     return
                 error_message = await exile_user(
-                    logging_embed, user, exile_duration, reason
+                    logging_embed,
+                    user,
+                    exile_duration,
+                    reason,
+                    author=interaction.user,
                 )
 
                 response_message.set_string(

--- a/services/moddingway/moddingway/services/exile_service.py
+++ b/services/moddingway/moddingway/services/exile_service.py
@@ -17,6 +17,8 @@ from moddingway.util import (
     timestamp_to_epoch,
 )
 
+from . import note_service
+
 settings = get_settings()
 logger = logging.getLogger(__name__)
 
@@ -26,6 +28,8 @@ async def exile_user(
     user: discord.Member,
     duration: datetime.timedelta,
     reason: str,
+    author: discord.User | discord.Member | None = None,
+    add_note: bool = True,
 ) -> str | None:
     db_user = users_database.get_user(user.id)
     if db_user:
@@ -115,6 +119,13 @@ async def exile_user(
         f"You are being exiled from NA Ultimate Raiding - FFXIV.\n**Reason:** {reason}\nExile expiration: <t:{timestamp}:R>",
         context="Exile",
     )
+
+    # sometimes we don't want to add a note (i.e. roulette)
+    if add_note:
+        note_author = author or user.guild.me
+        note_text = f"Exiled until <t:{timestamp}:F>. Reason: {reason}"
+        await note_service.add_note(logging_embed, user, note_text, note_author)
+        logging_embed.set_footer(text=f"Exile ID: {exile_id}")
 
     log_info_and_add_field(
         logging_embed,

--- a/services/moddingway/moddingway/services/strike_service.py
+++ b/services/moddingway/moddingway/services/strike_service.py
@@ -69,7 +69,9 @@ async def add_strike(
         f"<@{user.id}> was given a strike, bringing them to {db_user.get_strike_points()} points from {previous_points} points",
     )
 
-    punishment = await _apply_punishment(logging_embed, user, db_user, previous_points)
+    punishment = await _apply_punishment(
+        logging_embed, user, db_user, previous_points, author
+    )
     logging_embed.add_field(name="Punishment", value=punishment)
 
     # message user
@@ -183,6 +185,7 @@ async def _apply_punishment(
     user: discord.Member,
     db_user: User,
     previous_points: int,
+    author: discord.Member,
 ) -> str:
     total_points = db_user.get_strike_points()
 
@@ -196,7 +199,7 @@ async def _apply_punishment(
         await ban_service.ban_member(
             logging_embed,
             user,
-            "Your strike were severe or frequent to be removed from NA Ultimate Raiding - FFXIV",
+            "Your strikes were severe or frequent enough for you to be removed from NA Ultimate Raiding - FFXIV",
             False,
         )
         return punishment
@@ -208,6 +211,10 @@ async def _apply_punishment(
     else:
         punishment = f"{punishment_days} day exile"
         await exile_service.exile_user(
-            logging_embed, user, timedelta(days=punishment_days), exile_reason
+            logging_embed,
+            user,
+            timedelta(days=punishment_days),
+            exile_reason,
+            author=author,
         )
     return punishment

--- a/services/moddingway/pyproject.toml
+++ b/services/moddingway/pyproject.toml
@@ -71,4 +71,4 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 
 [tool.uv]
-required-version = "==0.11.14"
+required-version = ">=0.11.14,<0.12.0"

--- a/tests/moddingway/pyproject.toml
+++ b/tests/moddingway/pyproject.toml
@@ -3,6 +3,10 @@ name = "moddingway-tests"
 version = "0.0.1"
 requires-python = ">=3.14"
 
+[tool.ruff.lint.isort]
+known-first-party = ["moddingway", "moddingway_api"]
+combine-as-imports = true
+
 [tool.pytest.ini_options]
 pythonpath = ["../../services/moddingway"]
 testpaths = ["unit"]

--- a/tests/moddingway/unit/services/test_exile_service.py
+++ b/tests/moddingway/unit/services/test_exile_service.py
@@ -1,5 +1,6 @@
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 
+import discord
 import pytest
 from pytest_mock.plugin import MockerFixture
 
@@ -7,6 +8,48 @@ from moddingway import constants
 from moddingway.constants import UserRole
 from moddingway.database.models import User
 from moddingway.services import exile_service
+from moddingway.util import timestamp_to_epoch
+
+DEFAULT_DATETIME_NOW = datetime(2016, 05, 28, 8, 0, 0, tzinfo=UTC)
+
+
+def _mock_verified_exile_setup(mocker: MockerFixture, create_member, *, allows_dms=True):
+    mock_database_user = User(
+        user_id=1,
+        discord_user_id="12345",
+        discord_guild_id="1",
+        user_role=UserRole.USER,
+        temporary_points=0,
+        permanent_points=0,
+        is_banned=False,
+    )
+    mocker.patch(
+        "moddingway.database.exiles_database.get_user_active_exile", return_value=None
+    )
+    mocker.patch(
+        "moddingway.database.users_database.get_user", return_value=mock_database_user
+    )
+    create_user_mock = mocker.patch(
+        "moddingway.database.users_database.add_user", return_value=mock_database_user
+    )
+    exile_id = 4001
+    mocker.patch("moddingway.database.exiles_database.add_exile", return_value=exile_id)
+    mocked_add_note = mocker.patch(
+        "moddingway.services.exile_service.note_service.add_note",
+        new=mocker.AsyncMock(),
+    )
+    mocked_member = create_member(
+        roles=[constants.Role.VERIFIED], allows_dms=allows_dms
+    )
+    mocked_logging_embed = mocker.Mock()
+    return (
+        mock_database_user,
+        create_user_mock,
+        exile_id,
+        mocked_add_note,
+        mocked_member,
+        mocked_logging_embed,
+    )
 
 
 @pytest.mark.asyncio
@@ -29,6 +72,10 @@ async def test_exile_user__unverified(mocker: MockerFixture, create_member):
         "moddingway.database.exiles_database.get_user_active_exile", return_value=None
     )
     mocker.patch("moddingway.util.user_has_role", return_value=False)
+    mocked_add_note = mocker.patch(
+        "moddingway.services.exile_service.note_service.add_note",
+        new=mocker.AsyncMock(),
+    )
     # Act
     res = await exile_service.exile_user(
         mocker.Mock(description=""),
@@ -40,6 +87,7 @@ async def test_exile_user__unverified(mocker: MockerFixture, create_member):
     # Assert
     assert res is not None
     assert res == "User is not currently verified, no action will be taken"
+    mocked_add_note.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -47,29 +95,14 @@ async def test_exile_user__verified_existing_user_dm_failed(
     mocker: MockerFixture, create_member
 ):
     # Arrange
-    mock_database_user = User(
-        user_id=1,
-        discord_user_id="12345",
-        discord_guild_id="1",
-        user_role=UserRole.USER,
-        temporary_points=0,
-        permanent_points=0,
-        is_banned=False,
-    )
-    mocker.patch(
-        "moddingway.database.exiles_database.get_user_active_exile", return_value=None
-    )
-    mocker.patch(
-        "moddingway.database.users_database.get_user", return_value=mock_database_user
-    )
-    create_user_mock = mocker.patch(
-        "moddingway.database.users_database.add_user", return_value=mock_database_user
-    )
-    exile_id = 4001
-    mocker.patch("moddingway.database.exiles_database.add_exile", return_value=exile_id)
-
-    mocked_member = create_member(roles=[constants.Role.VERIFIED], allows_dms=False)
-    mocked_logging_embed = mocker.Mock()
+    (
+        _mock_database_user,
+        create_user_mock,
+        exile_id,
+        mocked_add_note,
+        mocked_member,
+        mocked_logging_embed,
+    ) = _mock_verified_exile_setup(mocker, create_member, allows_dms=False)
 
     # Act
     res = await exile_service.exile_user(
@@ -83,9 +116,74 @@ async def test_exile_user__verified_existing_user_dm_failed(
     assert res is None
     create_user_mock.assert_not_called()
     mocked_logging_embed.set_footer.assert_called_with(text=f"Exile ID: {exile_id}")
+    mocked_add_note.assert_called_once()
     # TODO check exile create call to confirm data is correct
 
     assert any(
         call[1].get("name", "") == "DM Status"
         for call in mocked_logging_embed.add_field.call_args_list
     )
+
+
+@pytest.mark.asyncio
+async def test_exile_user__adds_note_on_exile(mocker: MockerFixture, create_member):
+    # Arrange
+    reason = "rule violation"
+    duration = timedelta(days=1)
+    end_timestamp = DEFAULT_DATETIME_NOW + duration
+    timestamp = timestamp_to_epoch(end_timestamp)
+    mocked_author = mocker.Mock(spec=discord.Member)
+    mocked_author.id = 999
+
+    (
+        _mock_database_user,
+        _create_user_mock,
+        _exile_id,
+        mocked_add_note,
+        mocked_member,
+        mocked_logging_embed,
+    ) = _mock_verified_exile_setup(mocker, create_member)
+
+    # Act
+    await exile_service.exile_user(
+        mocked_logging_embed,
+        mocked_member,
+        duration,
+        reason,
+        author=mocked_author,
+    )
+
+    # Assert
+    mocked_add_note.assert_called_once_with(
+        mocked_logging_embed,
+        mocked_member,
+        f"Exiled until <t:{timestamp}:F>. Reason: {reason}",
+        mocked_author,
+    )
+
+
+@pytest.mark.asyncio
+async def test_exile_user__roulette_does_not_add_note(
+    mocker: MockerFixture, create_member
+):
+    # Arrange
+    (
+        _mock_database_user,
+        _create_user_mock,
+        _exile_id,
+        mocked_add_note,
+        mocked_member,
+        mocked_logging_embed,
+    ) = _mock_verified_exile_setup(mocker, create_member)
+
+    # Act
+    await exile_service.exile_user(
+        mocked_logging_embed,
+        mocked_member,
+        timedelta(hours=6),
+        "lost roulette",
+        add_note=False,
+    )
+
+    # Assert
+    mocked_add_note.assert_not_called()

--- a/tests/moddingway/unit/services/test_exile_service.py
+++ b/tests/moddingway/unit/services/test_exile_service.py
@@ -10,10 +10,12 @@ from moddingway.database.models import User
 from moddingway.services import exile_service
 from moddingway.util import timestamp_to_epoch
 
-DEFAULT_DATETIME_NOW = datetime(2016, 05, 28, 8, 0, 0, tzinfo=UTC)
+DEFAULT_DATETIME_NOW = datetime(2016, 5, 28, 8, 0, 0, tzinfo=UTC)
 
 
-def _mock_verified_exile_setup(mocker: MockerFixture, create_member, *, allows_dms=True):
+def _mock_verified_exile_setup(
+    mocker: MockerFixture, create_member, *, allows_dms=True
+):
     mock_database_user = User(
         user_id=1,
         discord_user_id="12345",

--- a/tests/moddingway/unit/services/test_exile_service.py
+++ b/tests/moddingway/unit/services/test_exile_service.py
@@ -10,7 +10,7 @@ from moddingway.database.models import User
 from moddingway.services import exile_service
 from moddingway.util import timestamp_to_epoch
 
-DEFAULT_DATETIME_NOW = datetime(2016, 5, 28, 8, 0, 0, tzinfo=UTC)
+DEFAULT_DATETIME_NOW = datetime(2019, 11, 19, 8, 0, 0, tzinfo=UTC)
 
 
 def _mock_verified_exile_setup(

--- a/tests/moddingway/unit/services/test_strike_service.py
+++ b/tests/moddingway/unit/services/test_strike_service.py
@@ -33,6 +33,8 @@ async def test_apply_punishment(
     create_db_user,
 ):
     mocked_user = mocker.Mock()
+    mocked_author = mocker.Mock(spec=discord.Member)
+    mocked_author.id = 99
     mocked_db_user = create_db_user(get_strike_points=total_points)
     mocked_ban_member = mocker.patch("moddingway.services.ban_service.ban_member")
     mocked_ban_user = mocker.patch("moddingway.services.ban_service.ban_user")
@@ -43,7 +45,7 @@ async def test_apply_punishment(
     mocked_exile_user = mocker.patch("moddingway.services.exile_service.exile_user")
 
     res = await strike_service._apply_punishment(
-        mocked_embed, mocked_user, mocked_db_user, previous_points
+        mocked_embed, mocked_user, mocked_db_user, previous_points, mocked_author
     )
     if total_points >= PERMANENT_BAN_STRIKE_THRESHOLD:
         mocked_ban_member.assert_called_once_with(
@@ -64,6 +66,7 @@ async def test_apply_punishment(
                 mocked_user,
                 timedelta(days=punishment_days),
                 mocker.ANY,
+                author=mocked_author,
             )
     assert res == expected_punishment
 
@@ -199,5 +202,5 @@ async def test_add_strike(
     mocked_update_user_strike_points.assert_called_with(mocked_db_user)
 
     mocked__apply_punishment.assert_called_with(
-        mocked_logging_embed, mocked_user, mocked_db_user, 0
+        mocked_logging_embed, mocked_user, mocked_db_user, 0, mocked_author
     )


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

Currently, when a user is muted, they do not receive a note on their profile. This PR changes it such that a note is created except in cases where the exile was due to losing roulette.

### Related Ticket

<!-- Examples: Fixes #123, Resolves #123, Closes #123, or Closes #NA -->

Closes #NA

## Type of Change

<!-- Bug fix? New feature? Breaking change? Documentation? -->

Feature

## Testing

<!-- Briefly describe how you verified these changes. -->

Tested by exiling user, checking notes, having them lose roulette, and checking notes again to confirm that a note was added from the original exile but not from the roulette.

## Checklist

- [X] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] Tests added and passing (if applicable)
- [x] Needs QA

---

> [!IMPORTANT]
> Checking **Needs QA** triggers an automated checklist.
> Open in **Draft mode** so you can fill it out before requesting review.
