### PR TITLE
redirects for .net -> .com

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,3 +11,15 @@ NODE_VERSION = "22.13.0"
 NEXT_DISABLE_SWC_BINARY_PATCHING = "1"
 NETLIFY_NEXT_PLUGIN_SKIP_INSTALL_DEPENDENCIES = "true"
 PNPM_FLAGS = "--shamefully-hoist"
+
+[[redirects]]
+  from = "https://naurffxiv.net/*"
+  to = "https://naurffxiv.com/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "https://www.naurffxiv.net/*"
+  to = "https://naurffxiv.com/:splat"
+  status = 301
+  force = true


### PR DESCRIPTION
## Description

Adds two forced domain-level redirects to the root `netlify.toml` so that `naurffxiv.net` and `www.naurffxiv.net` issue a 301 to their `naurffxiv.com` equivalent, preserving path and query string via `:splat`.

Previously both `.net` names were configured as Netlify domain aliases, which *serve* the site rather than redirecting it — leaving a full duplicate copy of the site live on a second domain. These rules make `.com` canonical.

Build config is untouched; only redirect blocks were appended.

### Related Ticket
Closes #446 

## Type of Change
Configuration change (non-breaking). No application code or build pipeline modified.

## Testing
Uhhh idk its a domain change.

## Testing

<!-- Briefly describe how you verified these changes. -->

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] Tests added and passing (if applicable)
- [ ] Needs QA
