### PR TITLE
Ignore typescript major bumps pending typescript-eslint support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,14 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "build"
+    # typescript-eslint has no published version that supports TypeScript
+    # >=6.1.0 (peer range: ">=4.8.4 <6.1.0"), and TS 7.0 support was closed
+    # "not planned": https://github.com/typescript-eslint/typescript-eslint/issues/12518
+    # Revisit once that changes; until then major bumps just produce PRs we
+    # can't merge without dropping type-aware linting.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       linting:
         patterns:
@@ -25,6 +33,7 @@ updates:
           - "eslint-*"
           - "prettier"
           - "@typescript-eslint/*"
+          - "typescript-eslint"
       npm-other:
         patterns: ["*"]
         exclude-patterns:
@@ -32,6 +41,7 @@ updates:
           - "eslint-*"
           - "prettier"
           - "@typescript-eslint/*"
+          - "typescript-eslint"
 
   - package-ecosystem: "npm"
     directory: "/services/naurffxiv"
@@ -40,6 +50,14 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "build"
+    # typescript-eslint has no published version that supports TypeScript
+    # >=6.1.0 (peer range: ">=4.8.4 <6.1.0"), and TS 7.0 support was closed
+    # "not planned": https://github.com/typescript-eslint/typescript-eslint/issues/12518
+    # Revisit once that changes; until then major bumps just produce PRs we
+    # can't merge without dropping type-aware linting.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       next-and-react:
         patterns:
@@ -54,6 +72,7 @@ updates:
           - "eslint-*"
           - "prettier"
           - "@typescript-eslint/*"
+          - "typescript-eslint"
       npm-other:
         patterns: ["*"]
         exclude-patterns:
@@ -66,6 +85,7 @@ updates:
           - "eslint-*"
           - "prettier"
           - "@typescript-eslint/*"
+          - "typescript-eslint"
 
   - package-ecosystem: "npm"
     directory: "/tests/e2e"
@@ -74,6 +94,14 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "build"
+    # typescript-eslint has no published version that supports TypeScript
+    # >=6.1.0 (peer range: ">=4.8.4 <6.1.0"), and TS 7.0 support was closed
+    # "not planned": https://github.com/typescript-eslint/typescript-eslint/issues/12518
+    # Revisit once that changes; until then major bumps just produce PRs we
+    # can't merge without dropping type-aware linting.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-all:
         patterns: ["*"]


### PR DESCRIPTION
> [!WARNING]
>These changes were AI-assisted with human supervision throughout; all changes reviewed and 
>double-checked by @Luna-Salamanca before merge.
## Description

Researched (TypeScript → latest) instead of bumping it. typescript-eslint doesn't support TS past 6.0.x yet, and TS 7 support was closed "not planned" upstream ([issue](https://github.com/typescript-eslint/typescript-eslint/issues/12518)). Even 6.0.3 wasn't worth it, still a dead end, just closer to it.

So instead: told dependabot to stop proposing TS major bumps we can't take, with a comment explaining why so it's not a mystery later. Also fixed typescript-eslint (the unified package) not matching the linting group anymore after the eslint 9 migration.

### Related Ticket

<!-- Examples: Fixes #123, Resolves #123, Closes #123, or Closes #NA -->

Closes #NA

## Type of Change

 Chore / tooling (dependabot config only)

## Testing

Config-only change, nothing to run.


## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] Tests added and passing (if applicable)
- [ ] Needs QA

---

> [!IMPORTANT]
> Checking **Needs QA** triggers an automated checklist.
> Open in **Draft mode** so you can fill it out before requesting review.
