### PR TITLE
chore(deps): upgrade pnpm to v11.20.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,12 +1,1 @@
-# Core resolution and hoisting
-shamefully-hoist=false
-strict-peer-dependencies=true
-auto-install-peers=true
-engine-strict=true
-
-# Modern Monorepo Optimization
-dedupe-peer-dependents=true
-resolve-peers-from-workspace-root=true
-
-# Security & Reliability
-verify-store-integrity=true
+# pnpm v11 only reads registry/auth here; everything else is in pnpm-workspace.yaml

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   ],
   "engines": {
     "node": ">=22.13.0",
-    "pnpm": ">=10.29.2"
+    "pnpm": ">=11.20.0"
   },
-  "packageManager": "pnpm@10.29.2",
+  "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee",
   "license": "MIT",
   "type": "commonjs",
   "devDependencies": {
@@ -37,31 +37,5 @@
   },
   "overrides": {
     "glob": "^11.0.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "@types/react": "19.2.18",
-      "@types/react-dom": "19.2.4",
-      "rollup": ">=4.59.0",
-      "vite": "^8.2.0",
-      "js-yaml": "^4.3.0",
-      "brace-expansion": "5.0.8",
-      "brace-expansion@^1.1.7": "1.1.18",
-      "next>postcss": "8.5.18",
-      "sharp@<0.35.0": "0.35.3",
-      "flatted": "3.4.2",
-      "ajv": "6.14.0",
-      "minimatch@^3.1.0": "3.1.5",
-      "minimatch@^9.0.5": "9.0.7",
-      "picomatch@^2.3.0": "2.3.2",
-      "picomatch@^4.0.0": "4.0.4",
-      "yaml@^2.8.0": "2.8.3"
-    },
-    "onlyBuiltDependencies": [
-      "@parcel/watcher",
-      "esbuild",
-      "sharp",
-      "unrs-resolver"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,42 @@ packages:
   - "packages/shared"
   - "tests/e2e"
   - "tests/naurffxiv"
+
+# Core resolution and hoisting (moved from .npmrc)
+shamefullyHoist: false
+strictPeerDependencies: true
+autoInstallPeers: true
+engineStrict: true
+
+# Modern Monorepo Optimization
+dedupePeerDependents: true
+resolvePeersFromWorkspaceRoot: true
+
+# Security & Reliability
+verifyStoreIntegrity: true
+
+# Moved from package.json's "pnpm" field, which v11 no longer reads
+overrides:
+  "@types/react": "19.2.18"
+  "@types/react-dom": "19.2.4"
+  rollup: ">=4.59.0"
+  vite: "^8.2.0"
+  js-yaml: "^4.3.0"
+  brace-expansion: "5.0.8"
+  "brace-expansion@^1.1.7": "1.1.18"
+  "next>postcss": "8.5.18"
+  "sharp@<0.35.0": "0.35.3"
+  flatted: "3.4.2"
+  ajv: "6.14.0"
+  "minimatch@^3.1.0": "3.1.5"
+  "minimatch@^9.0.5": "9.0.7"
+  "picomatch@^2.3.0": "2.3.2"
+  "picomatch@^4.0.0": "4.0.4"
+  "yaml@^2.8.0": "2.8.3"
+
+# Replaces onlyBuiltDependencies (removed in v11)
+allowBuilds:
+  "@parcel/watcher": true
+  esbuild: true
+  sharp: true
+  unrs-resolver: true

--- a/services/naurffxiv/Dockerfile
+++ b/services/naurffxiv/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 
 FROM node:22-bookworm-slim AS base
-RUN corepack enable && corepack prepare pnpm@10.29.2 --activate
+RUN corepack enable && corepack prepare pnpm@11.20.0 --activate
 
 # Prune stage: This breaks the app into "json" (dependencies) and "full" (source)
 FROM base AS prune

--- a/services/naurffxiv/README.md
+++ b/services/naurffxiv/README.md
@@ -70,7 +70,7 @@ If you prefer to run the project directly on your machine without Docker.
 
 ### Prerequisites
 
-You need **Node.js v22+** and **pnpm v10+**.
+You need **Node.js v22+** and **pnpm v11+**.
 
 #### Check Installed Versions
 
@@ -86,7 +86,7 @@ Expected output:
 v22.6.0
 
 ❯ pnpm -v
-10.29.2
+11.20.0
 ```
 
 ### Installation

--- a/services/naurffxiv/package.json
+++ b/services/naurffxiv/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "engines": {
     "node": ">=22.13.0",
-    "pnpm": ">=10.29.2"
+    "pnpm": ">=11.20.0"
   },
   "scripts": {
     "dev": "pnpm check:routes && pnpm exec next dev",

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "engines": {
     "node": ">=22.13.0",
-    "pnpm": ">=10.29.2"
+    "pnpm": ">=11.20.0"
   },
   "description": "End-to-end tests for NAUR Monorepo",
   "scripts": {


### PR DESCRIPTION
> [!WARNING]
>These changes were AI-assisted with human supervision throughout; all changes reviewed and 
>double-checked by @Luna-Salamanca before merge.
## Description

Upgrades pnpm from 10.29.2 to 11.20.0 (Ticket #459 named 11.17.0, but current latest stable is 11.20.0; 12.0.0-rc.0 exists but isn't stable, targeted 11.20.0 instead).

v11 stops reading the `pnpm` field in `package.json` entirely, and stops reading anything from `.npmrc` except registry/auth credentials. Both had real, load-bearing content in this repo:

- `package.json`'s `pnpm.overrides` (15 entries, mostly security/transitive-dep pins) → moved to `pnpm-workspace.yaml`'s `overrides`
- `package.json`'s `pnpm.onlyBuiltDependencies` → moved to the new `allowBuilds` boolean map. Verified `sharp`, `esbuild`, `@parcel/watcher`, and `unrs-resolver` all still run their install/build scripts correctly.
- `.npmrc`'s 7 settings (none were registry/auth) → moved to `pnpm-workspace.yaml` in camelCase. `.npmrc` now just carries a pointer comment.

Swept the repo for usage of anything else v11 removes, and for every other reference to `pnpm` across the whole tree (checked every `package.json`'s `engines.pnpm` individually). Found and fixed three more real misses:

- **`services/naurffxiv/Dockerfile`** hardcoded `corepack prepare pnpm@10.29.2 --activate`, bypassing `packageManager` entirely. Fixed and verified against a real Docker build, corepack + `pnpm install --frozen-lockfile` both succeed cleanly against v11.
- **`services/naurffxiv/README.md`** still documented "pnpm v10+" / `10.29.2`. Updated.
- **`services/naurffxiv/package.json`** and **`tests/e2e/package.json`** each had their own `engines.pnpm: ">=10.29.2"` pin. Updated both.

CI workflows use `pnpm/action-setup` with no hardcoded version, so they read `packageManager` automatically, no changes needed.

Cross-checked the whole migration against the official `pnpm-v10-to-v11` codemod (dry-run: 0 files it would modify) and against v11's new default-on strict settings (`minimumReleaseAge`, `blockExoticSubdeps`), no git/tarball-hosted deps exist in this repo, so they have no effect.

**Note**: a real Docker build against this Dockerfile currently fails, but at a later, unrelated step (`@naur/shared/types` fails to resolve in the `builder` stage, missing `COPY packages/shared` line). Confirmed via `git log` this predates all of this work. Filed separately as its own bug, not folded into this PR.

**Heads up for other devs**: if you hit `ERR_PNPM_UNSUPPORTED_ENGINE` after pulling this, your global pnpm binary is still 10.x and shadowing corepack's shim in PATH, run `npm install -g pnpm@11.20.0` (or however you installed pnpm globally) to fix it.

### Related Ticket

Closes #459

## Type of Change

- [x] Chore / dependency upgrade

## Testing

- `pnpm install`: clean full reinstall against the new store format
- `pnpm typecheck`: 4/4 pass
- `pnpm lint`: 0 errors, unchanged warning baseline
- `pnpm test`: 7/7 pass (including e2e)
- `pnpm build`: production build succeeds
- `pnpm check:routes`: the chalk-dependent script runs correctly
- Confirmed all `allowBuilds`-gated packages still execute their install scripts
- Cross-checked against the official `pnpm-v10-to-v11` codemod (dry-run: 0 files would be modified)
- Real Docker build confirms the pnpm version fix works (fails later at an unrelated, pre-existing bug, filed separately)

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] Tests added and passing (if applicable)
- [ ] Needs QA