### PR TITLE
fix(naurffxiv): resolve @naur/shared missing from Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,8 @@
 # Allow source code directories
 !services/naurffxiv/
 !services/naurffxiv/**
+!packages/shared/
+!packages/shared/**
 #!services/raidingway/
 #!services/raidingway/**
 

--- a/services/naurffxiv/Dockerfile
+++ b/services/naurffxiv/Dockerfile
@@ -30,6 +30,7 @@ FROM base AS dev
 WORKDIR /app
 COPY --from=installer /app/ .
 COPY package.json turbo.json pnpm-workspace.yaml ./
+COPY packages/shared packages/shared
 COPY services/naurffxiv services/naurffxiv
 CMD ["sh", "-c", "pnpm install --ignore-scripts && pnpm --filter naurffxiv dev"]
 
@@ -38,6 +39,7 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=installer /app/ .
 COPY package.json turbo.json pnpm-workspace.yaml ./
+COPY packages/shared packages/shared
 COPY services/naurffxiv services/naurffxiv
 
 # Build with cache mount for Next.js

--- a/services/naurffxiv/docker-compose.yml
+++ b/services/naurffxiv/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "3000:3000"
     volumes:
       - .:/app/services/naurffxiv:z
+      - ../../packages/shared:/app/packages/shared:z
       - /app/services/naurffxiv/node_modules
       - /app/services/naurffxiv/.next
     environment:


### PR DESCRIPTION
## Description

Docker build failed: `Module not found: Can't resolve '@naur/shared/types'`.

Two stacked, pre-existing bugs:
- `Dockerfile` never copied `packages/shared` into the `builder`/`dev` stages
- `.dockerignore`'s allowlist never included `packages/shared`, so it never reached the build context

Also added a `packages/shared` volume mount to `docker-compose.yml`'s `dev` service for hot-reload parity.

### Related Ticket

Closes #508

## Type of Change

Bug fix

## Testing

All passing

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] Tests added and passing (if applicable)
- [ ] Needs QA